### PR TITLE
Add executeQueryNormally method in HasFakeableResponse trait

### DIFF
--- a/src/Traits/DataEntity/HasFakeableResponse.php
+++ b/src/Traits/DataEntity/HasFakeableResponse.php
@@ -31,4 +31,9 @@ trait HasFakeableResponse
     {
         return static::$fake;
     }
+
+    public static function executeQueryNormally(): void
+    {
+        static::$fake = false;
+    }
 }


### PR DESCRIPTION
This commit introduces a new method named executeQueryNormally in the HasFakeableResponse trait. This new method allows to reset the static $fake variable to false, enabling the execution of queries in a normal, non-fake mode.
