### PR TITLE
Add DataEntitiesServiceProvider and stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,12 @@
         "allow-plugins": {
             "phpstan/extension-installer": true
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "BitMx\\DataEntities\\DataEntitiesServiceProvider"
+            ]
+        }
     }
 }

--- a/src/Commands/MakeDataEntity.php
+++ b/src/Commands/MakeDataEntity.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace BitMx\DataEntities\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+class MakeDataEntity extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:data-entity {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new data entity class';
+
+    protected string $namespace = 'App\DataEntities';
+
+    #[\Override]
+    protected function getStub(): string
+    {
+        return $this->getStubPath();
+    }
+
+    public function getStubPath(): string
+    {
+        return __DIR__.'/../../stubs/data-entity.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     */
+    #[\Override]
+    protected function getDefaultNamespace(mixed $rootNamespace): string
+    {
+        return $this->namespace;
+    }
+}

--- a/src/DataEntitiesServiceProvider.php
+++ b/src/DataEntitiesServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BitMx\DataEntities;
+
+use Illuminate\Support\ServiceProvider;
+
+class DataEntitiesServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->registerCommands();
+        }
+    }
+
+    protected function registerCommands(): void
+    {
+        $this->commands([
+            Commands\MakeDataEntity::class,
+        ]);
+    }
+}

--- a/stubs/data-entity.stub
+++ b/stubs/data-entity.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use BitMx\DataEntities\DataEntity;
+use BitMx\DataEntities\Enums\Method;
+
+class {{ class }} extends DataEntity
+{
+    protected ?Method $method = Method::SELECT;
+
+    #[\Override]
+    public function resolveStoreProcedure(): string
+    {
+        //
+    }
+
+    #[\Override]
+    public function defaultParameters(): array
+    {
+        return [
+            //
+        ];
+    }
+}


### PR DESCRIPTION
This commit introduces the DataEntitiesServiceProvider, responsible for registering console commands if the app is running in console mode. It also includes a new command class "MakeDataEntity" and its associated stub file to help generate new data entity classes more conveniently. These new classes have been added to the 'providers' section in the composer.json file to support automatic discovery.
