### PR TITLE
Handle non-array data in Processor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "bit-mx/data-entities",
     "type": "library",
     "license": "MIT",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "autoload": {
         "psr-4": {
             "BitMx\\DataEntities\\": "src/"

--- a/src/Processors/Processor.php
+++ b/src/Processors/Processor.php
@@ -45,6 +45,10 @@ class Processor implements ProcessorContract
         try {
             $data = call_user_func([$this->getClient(), $this->getExecuter()], $this->prepareQuery(), $this->pendingQuery->parameters()->all());
 
+            if (! is_array($data)) {
+                $data = [];
+            }
+
             $data = json_decode((string) json_encode($data), true);
 
             $isSuccess = true;


### PR DESCRIPTION
This change ensures that the Processor can handle instances where the response from a client call is not an array. If the response isn't an array, it converts it into an empty array to avoid possible errors or inconsistencies in further processing. This increases code robustness.
