### PR TITLE
Add configuration file for DataEntitiesServiceProvider

### DIFF
--- a/config/data-entities.php
+++ b/config/data-entities.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'database' => env('DATA_ENTITIES_CONNECTION', 'sqlsrv'),
+];

--- a/src/DataEntitiesServiceProvider.php
+++ b/src/DataEntitiesServiceProvider.php
@@ -6,11 +6,20 @@ use Illuminate\Support\ServiceProvider;
 
 class DataEntitiesServiceProvider extends ServiceProvider
 {
+    public function boot(): void
+    {
+        $this->publishes([
+            __DIR__.'/../config/data-entities.php' => config_path('data-entities.php'),
+        ], 'config');
+    }
+
     public function register(): void
     {
         if ($this->app->runningInConsole()) {
             $this->registerCommands();
         }
+
+        $this->mergeConfigFrom(__DIR__.'/../config/data-entities.php', 'data-entities');
     }
 
     protected function registerCommands(): void

--- a/src/Traits/DataEntity/HasConnection.php
+++ b/src/Traits/DataEntity/HasConnection.php
@@ -2,12 +2,10 @@
 
 namespace BitMx\DataEntities\Traits\DataEntity;
 
-use Illuminate\Support\Facades\Config;
-
 trait HasConnection
 {
     public function resolveDatabaseConnection(): string
     {
-        return Config::get('database.default', 'sqlsrv');
+        return config('data-entities.database', 'sqlsrv');
     }
 }


### PR DESCRIPTION
Introduced a new config file for the DataEntitiesServiceProvider. This file contains database related settings and is published to the Laravel application's config directory on boot. Also, updated the HasConnection trait to fetch the database connection details from the new config file.
