### PR TITLE
Add DataEntityFactory and related classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": "^8.2",
         "illuminate/support": "^10.0 || ^11.0",
-        "illuminate/database": "^10.0 || ^11.0"
+        "illuminate/database": "^10.0 || ^11.0",
+        "fakerphp/faker": "^1.23"
     },
     "require-dev": {
         "laravel/pint": "^1.15",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,9 @@
 parameters:
     ignoreErrors:
         -
+            message: "#^Unsafe usage of new static\\(\\)\\.$#"
+            path: src/Factories/DataEntityFactory.php
+        -
             message: "$Parameter #1 \\$callback of function call_user_func expects callable$"
             count: 1
             path: src/Processors/Processor.php

--- a/src/Commands/MakeDataEntityFactory.php
+++ b/src/Commands/MakeDataEntityFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BitMx\DataEntities\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+
+class MakeDataEntityFactory extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:data-entity-factory {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new data entity factory class';
+
+    protected string $namespace = 'Test\RequestFactories';
+
+    #[\Override]
+    protected function getStub(): string
+    {
+        return $this->getStubPath();
+    }
+
+    public function getStubPath(): string
+    {
+        return __DIR__.'/../../stubs/data-entity-factory.stub';
+    }
+
+    /**
+     * @param  string  $name
+     */
+    protected function getPath(mixed $name): string
+    {
+        $name = Str::replaceFirst($this->rootNamespace(), '', $name);
+
+        return base_path('tests').str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Get the root namespace for the class.
+     */
+    protected function rootNamespace(): string
+    {
+        return 'Tests';
+    }
+
+    /**
+     * @param  string  $rootNamespace
+     */
+    protected function getDefaultNamespace(mixed $rootNamespace): string
+    {
+        return $rootNamespace.'\RequestFactories';
+    }
+}

--- a/src/Commands/MakeDataEntityFactory.php
+++ b/src/Commands/MakeDataEntityFactory.php
@@ -57,6 +57,6 @@ class MakeDataEntityFactory extends GeneratorCommand
      */
     protected function getDefaultNamespace(mixed $rootNamespace): string
     {
-        return $rootNamespace.'\RequestFactories';
+        return $rootNamespace.'\DataEntityFactories';
     }
 }

--- a/src/DataEntitiesServiceProvider.php
+++ b/src/DataEntitiesServiceProvider.php
@@ -26,6 +26,7 @@ class DataEntitiesServiceProvider extends ServiceProvider
     {
         $this->commands([
             Commands\MakeDataEntity::class,
+            Commands\MakeDataEntityFactory::class,
         ]);
     }
 }

--- a/src/Factories/CreateFactoryData.php
+++ b/src/Factories/CreateFactoryData.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BitMx\DataEntities\Factories;
+
+class CreateFactoryData
+{
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function __invoke(DataEntityFactory $factory): array
+    {
+        return $factory->getData();
+    }
+}

--- a/src/Factories/DataEntityFactory.php
+++ b/src/Factories/DataEntityFactory.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace BitMx\DataEntities\Factories;
+
+use Faker\Generator;
+use Illuminate\Support\Arr;
+
+abstract class DataEntityFactory
+{
+    protected Generator $faker;
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     * @param  array<array-key, mixed>  $without
+     */
+    public function __construct(
+        protected readonly array $attributes = [],
+        public readonly array $without = [],
+    ) {
+        $this->faker = app(Generator::class);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public static function new(
+        array $attributes = [],
+    ): static {
+        return (new static())->state($attributes)->newInstance();
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     * @param  array<array-key, mixed>  $without
+     */
+    protected function newInstance(
+        array $attributes = [],
+        array $without = [],
+    ): static {
+        return new static(
+            attributes: array_replace_recursive(
+                $this->attributes,
+                $attributes,
+            ),
+            without: array_merge(
+                $this->without,
+                $without,
+            ),
+        );
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     */
+    public function state(array $attributes): static
+    {
+        return $this->newInstance(
+            attributes: $attributes,
+        );
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getData(): array
+    {
+        return array_merge(
+            $this->definition(),
+            $this->attributes
+        );
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    abstract public function definition(): array;
+
+    /**
+     * @param  array<array-key, mixed>|string  $attributes
+     */
+    public function without(array|string $attributes): static
+    {
+        return $this->newInstance(
+            without: Arr::wrap($attributes),
+        );
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $attributes
+     * @return array<array-key, mixed>
+     */
+    public function create(array $attributes = []): array
+    {
+        return (new CreateFactoryData)($this->state($attributes));
+    }
+}

--- a/src/Factories/FactoryData.php
+++ b/src/Factories/FactoryData.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BitMx\DataEntities\Factories;
+
+readonly class FactoryData
+{
+    /**
+     * @param  array<array-key, mixed>  $definition
+     * @param  array<array-key, mixed>  $attributes
+     * @param  array<array-key, mixed>  $without
+     */
+    public function __construct(
+        private array $definition,
+        private array $attributes,
+        private array $without,
+    ) {
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getData(): array
+    {
+        return collect($this->getAttributes())
+            ->forget($this->getWithout())
+            ->all();
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getAttributes(): array
+    {
+        return array_replace_recursive($this->definition, $this->attributes);
+    }
+
+    /**
+     * @return array<int, array-key>
+     */
+    public function getWithout(): array
+    {
+        return $this->without;
+    }
+}

--- a/src/Responses/MockResponse.php
+++ b/src/Responses/MockResponse.php
@@ -2,20 +2,22 @@
 
 namespace BitMx\DataEntities\Responses;
 
+use BitMx\DataEntities\Factories\DataEntityFactory;
+
 final class MockResponse
 {
     /**
      * @param  array<array-key, mixed>  $data
      */
     public function __construct(
-        protected array $data,
+        protected array|DataEntityFactory $data,
     ) {
     }
 
     /**
      * @param  array<array-key, mixed>  $data
      */
-    public static function make(array $data): static
+    public static function make(array|DataEntityFactory $data): static
     {
         return new self($data);
     }
@@ -25,6 +27,10 @@ final class MockResponse
      */
     public function data(): array
     {
+        if ($this->data instanceof DataEntityFactory) {
+            return $this->data->create();
+        }
+
         return $this->data;
     }
 }

--- a/stubs/data-entity-factory.stub
+++ b/stubs/data-entity-factory.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+use BitMx\DataEntities\Factories\DataEntityFactory;
+
+class {{ class }} extends DataEntityFactory
+{
+    /**
+     * @inheritDoc
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}


### PR DESCRIPTION
New classes for data entity factories were implemented, including DataEntityFactory, CreateFactoryData and FactoryData. Also, the `data()` method in MockResponse was refactored to handle instances of the DataEntityFactory and 'fakerphp/faker' was added to the composer.json file. A new error ignore entry was added in phpstan-baseline.neon to manage the unsafe usage of 'new static'.
