### PR TITLE
Add ResponseTypeEnum and update processor

### DIFF
--- a/src/DataEntitiesServiceProvider.php
+++ b/src/DataEntitiesServiceProvider.php
@@ -11,6 +11,8 @@ class DataEntitiesServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/data-entities.php' => config_path('data-entities.php'),
         ], 'config');
+
+        DataEntity::resetMock();
     }
 
     public function register(): void

--- a/src/DataEntity.php
+++ b/src/DataEntity.php
@@ -3,6 +3,7 @@
 namespace BitMx\DataEntities;
 
 use BitMx\DataEntities\Enums\Method;
+use BitMx\DataEntities\Enums\ResponseTypeEnum;
 use BitMx\DataEntities\Responses\Response;
 use BitMx\DataEntities\Traits\DataEntity\Assertable;
 use BitMx\DataEntities\Traits\DataEntity\Bootable;
@@ -26,6 +27,8 @@ abstract class DataEntity
 
     protected ?Method $method = null;
 
+    protected ?ResponseTypeEnum $responseType = null;
+
     abstract public function resolveStoreProcedure(): string;
 
     public function createDtoFromResponse(Response $response): mixed
@@ -40,5 +43,14 @@ abstract class DataEntity
         }
 
         return $this->method;
+    }
+
+    public function getResponseType(): ResponseTypeEnum
+    {
+        if (! isset($this->responseType)) {
+            throw new \LogicException('Your data entity is missing a response type. You must add a response type property like [protected ResponseTypeEnum $responseType = ResponseTypeEnum::COLLECTION]');
+        }
+
+        return $this->responseType;
     }
 }

--- a/src/Enums/ResponseTypeEnum.php
+++ b/src/Enums/ResponseTypeEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BitMx\DataEntities\Enums;
+
+enum ResponseTypeEnum
+{
+    case SINGLE;
+    case COLLECTION;
+}

--- a/src/Factories/DataEntityFactory.php
+++ b/src/Factories/DataEntityFactory.php
@@ -15,7 +15,8 @@ abstract class DataEntityFactory
      */
     public function __construct(
         protected readonly array $attributes = [],
-        public readonly array $without = [],
+        protected readonly array $without = [],
+        protected readonly int $times = 1,
     ) {
         $this->faker = app(Generator::class);
     }
@@ -36,6 +37,7 @@ abstract class DataEntityFactory
     protected function newInstance(
         array $attributes = [],
         array $without = [],
+        int $times = 1,
     ): static {
         return new static(
             attributes: array_replace_recursive(
@@ -46,6 +48,7 @@ abstract class DataEntityFactory
                 $this->without,
                 $without,
             ),
+            times: $times,
         );
     }
 
@@ -56,6 +59,13 @@ abstract class DataEntityFactory
     {
         return $this->newInstance(
             attributes: $attributes,
+        );
+    }
+
+    public function count(int $times): static
+    {
+        return $this->newInstance(
+            times: $times,
         );
     }
 
@@ -91,6 +101,14 @@ abstract class DataEntityFactory
      */
     public function create(array $attributes = []): array
     {
-        return (new CreateFactoryData)($this->state($attributes));
+        if ($this->times === 1) {
+            return (new CreateFactoryData)($this->state($attributes));
+        }
+
+        return collect()
+            ->times($this->times, function () use ($attributes) {
+                return (new CreateFactoryData)($this->state($attributes));
+            })
+            ->all();
     }
 }

--- a/src/Processors/Processor.php
+++ b/src/Processors/Processor.php
@@ -4,6 +4,7 @@ namespace BitMx\DataEntities\Processors;
 
 use BitMx\DataEntities\Contracts\ProcessorContract;
 use BitMx\DataEntities\Enums\Method;
+use BitMx\DataEntities\Enums\ResponseTypeEnum;
 use BitMx\DataEntities\PendingQuery;
 use BitMx\DataEntities\Responses\Response;
 use BitMx\DataEntities\Traits\Executer\HasQuery;
@@ -49,7 +50,7 @@ class Processor implements ProcessorContract
                 $data = [];
             }
 
-            $data = json_decode((string) json_encode($data), true);
+            $data = $this->createDataArray($data);
 
             $isSuccess = true;
         } catch (QueryException $ex) {
@@ -71,5 +72,18 @@ class Processor implements ProcessorContract
             Method::SELECT => 'select',
             Method::STATEMENT => 'statement',
         };
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @return array<array-key, mixed>
+     */
+    protected function createDataArray(array $data): array
+    {
+        if ($this->pendingQuery->getDataEntity()->getResponseType() === ResponseTypeEnum::SINGLE) {
+            return json_decode((string) json_encode($data[0]), true);
+        }
+
+        return json_decode((string) json_encode($data), true);
     }
 }

--- a/stubs/data-entity.stub
+++ b/stubs/data-entity.stub
@@ -4,15 +4,18 @@ namespace {{ namespace }};
 
 use BitMx\DataEntities\DataEntity;
 use BitMx\DataEntities\Enums\Method;
+use BitMx\DataEntities\Enums\ResponseTypeEnum;
 
 class {{ class }} extends DataEntity
 {
     protected ?Method $method = Method::SELECT;
 
+    protected ?ResponseTypeEnum $responseType = ResponseTypeEnum::SINGLE;
+
     #[\Override]
     public function resolveStoreProcedure(): string
     {
-        //
+        return '';
     }
 
     #[\Override]


### PR DESCRIPTION
A new enumeration called ResponseTypeEnum has been added and used in the Processor class to distinguish between SINGLE and COLLECTION response types. The Processor class has been updated to properly handle these different response types. Additionally, the functionality in the DataEntityFactory class was extended to generate multiple entity instances at once.
