### PR TITLE
Add GitHub workflows for PHP 8.2 and 8.3 testing

### DIFF
--- a/.github/workflows/syntax-8.2.yml
+++ b/.github/workflows/syntax-8.2.yml
@@ -1,4 +1,4 @@
-name: Syntax
+name: syntax 8.2
 on:
   pull_request:
     branches:
@@ -35,5 +35,5 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
       - name: Run phpstan
-        run:  vendor/bin/phpstan analyse  -c phpstan.dist.neon src
+        run: vendor/bin/phpstan analyse  -c phpstan.dist.neon src
 

--- a/.github/workflows/syntax-8.3.yml
+++ b/.github/workflows/syntax-8.3.yml
@@ -1,4 +1,4 @@
-name: Syntax
+name: syntax 8.3
 on:
   pull_request:
     branches:

--- a/.github/workflows/tests-8.2.yml
+++ b/.github/workflows/tests-8.2.yml
@@ -18,9 +18,5 @@ jobs:
           coverage: none
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
-      - name: Create env
-        run: cp .env.example .env
-      - name: Create key
-        run: php artisan key:generate
       - name: Running tests
         run: vendor/bin/pest

--- a/.github/workflows/tests-8.2.yml
+++ b/.github/workflows/tests-8.2.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests 8.2
 on:
   pull_request:
     branches:

--- a/.github/workflows/tests-8.2.yml
+++ b/.github/workflows/tests-8.2.yml
@@ -1,0 +1,26 @@
+name: Tests
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          tools: composer:v2
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+      - name: Create env
+        run: cp .env.example .env
+      - name: Create key
+        run: php artisan key:generate
+      - name: Running tests
+        run: vendor/bin/pest

--- a/.github/workflows/tests-8.3.yml
+++ b/.github/workflows/tests-8.3.yml
@@ -18,9 +18,5 @@ jobs:
           coverage: none
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
-      - name: Create env
-        run: cp .env.example .env
-      - name: Create key
-        run: php artisan key:generate
       - name: Running tests
         run: vendor/bin/pest

--- a/.github/workflows/tests-8.3.yml
+++ b/.github/workflows/tests-8.3.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests 8.3
 on:
   pull_request:
     branches:

--- a/.github/workflows/tests-8.3.yml
+++ b/.github/workflows/tests-8.3.yml
@@ -1,0 +1,26 @@
+name: Tests
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          tools: composer:v2
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+      - name: Create env
+        run: cp .env.example .env
+      - name: Create key
+        run: php artisan key:generate
+      - name: Running tests
+        run: vendor/bin/pest


### PR DESCRIPTION
Two new workflows have been added to automatically run tests on pull requests targeted at the master branch. These workflows will setup the PHP environment for versions 8.2 and 8.3 respectively, install dependencies using Composer, copy environment variables, generate an encryption key, and finally run the tests.
