### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "bit-mx/data-entities",
     "type": "library",
     "license": "MIT",
-    "version": "0.0.5",
     "autoload": {
         "psr-4": {
             "BitMx\\DataEntities\\": "src/"


### PR DESCRIPTION
The version value has been removed from composer.json. This indicates that the project's versioning will no longer be managed directly within composer.json, but instead managed elsewhere, possibly by tags or other versioning patterns.
