### PR TITLE
Update README.md to correct exception handling description

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ if ($response->failed()) {
 
 ### throw
 
-By default, the Response object will throw an exception if the stored procedure fails. You can throw the exception
+By default, the Response object won't throw an exception if the stored procedure fails. You can throw an exception
 manually
 using the throw method.
 


### PR DESCRIPTION
The description regarding the default behavior of the `Response` object in the event of a stored procedure failure was incorrect. This commit updates README.md to accurately reflect that the `Response` object won't throw an exception by default.
