### PR TITLE
Add default value support for data method in Response

### DIFF
--- a/src/Responses/Response.php
+++ b/src/Responses/Response.php
@@ -44,10 +44,10 @@ readonly class Response
     /**
      * @return array<array-key, mixed>
      */
-    public function data(?string $key = null): array|string|null|int|float|bool
+    public function data(?string $key = null, mixed $default = null): array|string|null|int|float|bool
     {
         if (! is_null($key)) {
-            return $this->data[$key];
+            return $this->data[$key] ?? $default;
         }
 
         return $this->data;

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -58,6 +58,16 @@ it('can get the data by a key', function () {
     expect($response->data('key'))->toBe('test');
 });
 
+it('can get the data by a key with default', function () {
+    DataEntity::fake([
+        $this->dataEntity::class => MockResponse::make(['key' => 'test']),
+    ]);
+
+    $response = $this->dataEntity->execute();
+
+    expect($response->data('key2', 'key_default'))->toBe('key_default');
+});
+
 it('can get isEmpty is data is empty', function () {
     DataEntity::fake([
         $this->dataEntity::class => MockResponse::make([]),


### PR DESCRIPTION
A new parameter 'default' has been added to the 'data' method in the Response class. This allows for a default return value when a specified key doesn't exist in the data array. Corresponding unit tests have been updated to include coverage for this new feature.
