### PR TITLE
Refactor CastMap to CastAlias and improve Json casting

### DIFF
--- a/src/Casts/AsJson.php
+++ b/src/Casts/AsJson.php
@@ -29,6 +29,8 @@ class AsJson implements Castable
         }
 
         $flags = collect($this->attributes)
+            ->filter(fn (string $item): bool => str($item)->startsWith('JSON_'))
+            ->map(fn (string $item) => constant($item))
             ->reduce(function (int $carry, int $item): int {
                 return $carry | $item;
             }, 0);

--- a/src/Parameters/CastAlias.php
+++ b/src/Parameters/CastAlias.php
@@ -9,7 +9,7 @@ use BitMx\DataEntities\Casts\AsInteger;
 use BitMx\DataEntities\Casts\AsJson;
 use BitMx\DataEntities\Casts\AsString;
 
-class CastMap
+class CastAlias
 {
     /**
      * @return array<string, mixed>

--- a/src/Parameters/Transformer.php
+++ b/src/Parameters/Transformer.php
@@ -48,8 +48,8 @@ final class Transformer
 
         $attributes = $pieces->count() > 1 ? explode(',', $pieces->get(1, '')) : [];
 
-        if (array_key_exists($class, CastMap::get())) {
-            $class = CastMap::get()[$class];
+        if (array_key_exists($class, CastAlias::get())) {
+            $class = CastAlias::get()[$class];
         }
 
         if (! class_exists($class)) {
@@ -77,6 +77,7 @@ final class Transformer
     protected function getRule(): ?string
     {
         if (! array_key_exists($this->key, $this->casts)) {
+
             if (is_bool($this->value)) {
                 return 'bool';
             }

--- a/tests/Unit/Parameters/TransformerTest.php
+++ b/tests/Unit/Parameters/TransformerTest.php
@@ -104,6 +104,24 @@ it('cast a Date value', function () {
         ->toBe('2000-01-01');
 });
 
+it('cast a array value', function () {
+    $transformer = Transformer::make([1, 2, 3, 4], 'json_key', ['json_key' => 'json'], []);
+
+    $result = $transformer->transform();
+
+    expect($result)->toBeString()
+        ->toBe('[1,2,3,4]');
+});
+
+it('cast a array value with numbers', function () {
+    $transformer = Transformer::make(['1', '2', '3', '4'], 'json_key', ['json_key' => 'json:JSON_NUMERIC_CHECK'], []);
+
+    $result = $transformer->transform();
+
+    expect($result)->toBeString()
+        ->toBe('[1,2,3,4]');
+});
+
 it('cast a value of DateTimeInterface when no cast is set', function () {
     $transformer = Transformer::make(Carbon::parse('2000-01-01 12:30'), 'key', [], []);
 


### PR DESCRIPTION
The class `CastMap` has been renamed to `CastAlias` for better semantics. The code logic for Json casting has been updated to handle certain attributes starting with 'JSON_'. Additional tests have been added to ensure array values are properly cast to Json.
