### PR TITLE
Add middleware and exception handling capabilities

### DIFF
--- a/src/DataEntity.php
+++ b/src/DataEntity.php
@@ -12,6 +12,7 @@ use BitMx\DataEntities\Traits\DataEntity\HasAccessors;
 use BitMx\DataEntities\Traits\DataEntity\HasConnection;
 use BitMx\DataEntities\Traits\DataEntity\HasDumpableQuery;
 use BitMx\DataEntities\Traits\DataEntity\HasFakeableResponse;
+use BitMx\DataEntities\Traits\DataEntity\HasMiddleware;
 use BitMx\DataEntities\Traits\DataEntity\HasMutators;
 use BitMx\DataEntities\Traits\HasParameters;
 use BitMx\DataEntities\Traits\HasQueryStatements;
@@ -25,6 +26,7 @@ abstract class DataEntity
     use HasConnection;
     use HasDumpableQuery;
     use HasFakeableResponse;
+    use HasMiddleware;
     use HasMutators;
     use HasParameters;
     use HasQueryStatements;

--- a/src/Exceptions/DuplicatePipeNameException.php
+++ b/src/Exceptions/DuplicatePipeNameException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BitMx\DataEntities\Exceptions;
+
+class DuplicatePipeNameException extends \Exception
+{
+}

--- a/src/PendingQuery.php
+++ b/src/PendingQuery.php
@@ -7,9 +7,11 @@ use BitMx\DataEntities\PendingQuery\AddAccessors;
 use BitMx\DataEntities\PendingQuery\AddMutators;
 use BitMx\DataEntities\PendingQuery\BootDataEntity;
 use BitMx\DataEntities\PendingQuery\BootTraits;
+use BitMx\DataEntities\PendingQuery\MergeMiddlewares;
 use BitMx\DataEntities\PendingQuery\MergeParameters;
 use BitMx\DataEntities\PendingQuery\MergeQueryStatements;
 use BitMx\DataEntities\Traits\DataEntity\HasAccessors;
+use BitMx\DataEntities\Traits\DataEntity\HasMiddleware;
 use BitMx\DataEntities\Traits\DataEntity\HasMutators;
 use BitMx\DataEntities\Traits\HasParameters;
 use BitMx\DataEntities\Traits\HasQueryStatements;
@@ -18,6 +20,7 @@ use BitMx\DataEntities\Traits\PendingQuery\Tappable;
 class PendingQuery
 {
     use HasAccessors;
+    use HasMiddleware;
     use HasMutators;
     use HasParameters;
     use HasQueryStatements;
@@ -34,8 +37,12 @@ class PendingQuery
             ->tap(new BootTraits)
             ->tap(new MergeParameters)
             ->tap(new MergeQueryStatements)
+            ->tap(new MergeMiddlewares)
             ->tap(new AddMutators)
             ->tap(new AddAccessors);
+
+        // Execute the middleware
+        $this->middleware()->executeQueryPipeline($this);
     }
 
     public function getMethod(): Method

--- a/src/PendingQuery/AddMutators.php
+++ b/src/PendingQuery/AddMutators.php
@@ -4,7 +4,7 @@ namespace BitMx\DataEntities\PendingQuery;
 
 use BitMx\DataEntities\PendingQuery;
 
-class AddMutators
+readonly class AddMutators
 {
     public function __invoke(PendingQuery $pendingQuery): PendingQuery
     {

--- a/src/PendingQuery/BootDataEntity.php
+++ b/src/PendingQuery/BootDataEntity.php
@@ -4,7 +4,7 @@ namespace BitMx\DataEntities\PendingQuery;
 
 use BitMx\DataEntities\PendingQuery;
 
-class BootDataEntity
+readonly class BootDataEntity
 {
     public function __invoke(PendingQuery $pendingQuery): PendingQuery
     {

--- a/src/PendingQuery/MergeMiddlewares.php
+++ b/src/PendingQuery/MergeMiddlewares.php
@@ -4,11 +4,15 @@ namespace BitMx\DataEntities\PendingQuery;
 
 use BitMx\DataEntities\PendingQuery;
 
-readonly class AddAccessors
+readonly class MergeMiddlewares
 {
     public function __invoke(PendingQuery $pendingQuery): PendingQuery
     {
-        $pendingQuery->setAccessors($pendingQuery->getDataEntity()->getAccessors());
+        $dataEntity = $pendingQuery->getDataEntity();
+
+        $middleware = $dataEntity->middleware();
+
+        $pendingQuery->middleware()->merge($middleware);
 
         return $pendingQuery;
     }

--- a/src/Pipelines/MiddlewarePipeline.php
+++ b/src/Pipelines/MiddlewarePipeline.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace BitMx\DataEntities\Pipelines;
+
+use BitMx\DataEntities\PendingQuery;
+use BitMx\DataEntities\Responses\Response;
+
+class MiddlewarePipeline
+{
+    /**
+     * @var Pipeline<PendingQuery>
+     */
+    protected Pipeline $queryPipeline;
+
+    /**
+     * @var Pipeline<Response>
+     */
+    protected Pipeline $responsePipeline;
+
+    public function __construct()
+    {
+        $this->queryPipeline = new Pipeline;
+        $this->responsePipeline = new Pipeline;
+    }
+
+    public function onQuery(callable $callable, ?string $name = null): static
+    {
+        $this->queryPipeline->addPipe(static function (PendingQuery $pendingQuery) use ($callable): PendingQuery {
+
+            $result = $callable($pendingQuery);
+
+            return $result instanceof PendingQuery ? $result : $pendingQuery;
+        }, $name);
+
+        return $this;
+    }
+
+    public function onResponse(callable $callable, ?string $name = null): static
+    {
+        $this->responsePipeline->addPipe(static function (Response $response) use ($callable): Response {
+            $result = $callable($response);
+
+            return $result instanceof Response ? $result : $response;
+        }, $name);
+
+        return $this;
+    }
+
+    public function executeQueryPipeline(PendingQuery $pendingQuery): PendingQuery
+    {
+        return $this->queryPipeline->process($pendingQuery);
+    }
+
+    public function executeResponsePipeline(Response $response): Response
+    {
+        return $this->responsePipeline->process($response);
+    }
+
+    public function merge(MiddlewarePipeline $middlewarePipeline): static
+    {
+        $queryPipelines = array_merge(
+            $this->getQueryPipeline()->getPipes(),
+            $middlewarePipeline->getQueryPipeline()->getPipes()
+        );
+
+        $responsePipelines = array_merge(
+            $this->getResponsePipeline()->getPipes(),
+            $middlewarePipeline->getResponsePipeline()->getPipes()
+        );
+
+        $this->getQueryPipeline()->setPipes($queryPipelines);
+
+        $this->getResponsePipeline()->setPipes($responsePipelines);
+
+        return $this;
+    }
+
+    /**
+     * @return Pipeline<PendingQuery>
+     */
+    public function getQueryPipeline(): Pipeline
+    {
+        return $this->queryPipeline;
+    }
+
+    /**
+     * @return Pipeline<Response>
+     */
+    public function getResponsePipeline(): Pipeline
+    {
+        return $this->responsePipeline;
+    }
+}

--- a/src/Pipelines/Pipe.php
+++ b/src/Pipelines/Pipe.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BitMx\DataEntities\Pipelines;
+
+use BitMx\DataEntities\PendingQuery;
+use BitMx\DataEntities\Responses\Response;
+
+readonly class Pipe
+{
+    protected \Closure $callable;
+
+    /**
+     * Constructor
+     *
+     * @param  callable(Response|PendingQuery $payload): (Response|PendingQuery)  $callable
+     */
+    public function __construct(
+        callable $callable,
+
+        protected ?string $name = null,
+    ) {
+        $this->callable = $callable(...);
+    }
+
+    public function getCallable(): \Closure
+    {
+        return $this->callable;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Pipelines/Pipeline.php
+++ b/src/Pipelines/Pipeline.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace BitMx\DataEntities\Pipelines;
+
+use BitMx\DataEntities\Exceptions\DuplicatePipeNameException;
+
+/**
+ * @template T
+ */
+class Pipeline
+{
+    /**
+     * @var array<int, Pipe>
+     */
+    protected array $pipes = [];
+
+    /**
+     * @param  T  $payload
+     * @return T
+     */
+    public function process(mixed $payload): mixed
+    {
+        foreach ($this->pipes as $pipe) {
+            $payload = $pipe->getCallable()($payload);
+        }
+
+        return $payload;
+    }
+
+    public function addPipe(callable $callable, ?string $name = null): void
+    {
+        if (is_string($name) && $this->pipeExists($name)) {
+            throw new DuplicatePipeNameException($name);
+        }
+
+        $this->pipes[] = new Pipe($callable, $name);
+    }
+
+    protected function pipeExists(string $name): bool
+    {
+        return collect($this->pipes)->contains(fn (Pipe $pipe) => $pipe->getName() === $name);
+    }
+
+    /**
+     * @return array<int, Pipe>
+     */
+    public function getPipes(): array
+    {
+        return $this->pipes;
+    }
+
+    /**
+     * @param  array<int, Pipe>  $pipes
+     */
+    public function setPipes(array $pipes): void
+    {
+        $this->pipes = $pipes;
+    }
+}

--- a/src/Processors/MockProcessor.php
+++ b/src/Processors/MockProcessor.php
@@ -46,6 +46,11 @@ class MockProcessor implements ProcessorContract
 
     protected function createFakeResponse(MockResponse $mockResponse): Response
     {
+
+        if ($mockResponse->data() instanceof \Throwable) {
+            return new Response($this->pendingQuery, [], false, $mockResponse->data());
+        }
+
         return new Response($this->pendingQuery, $mockResponse->data(), true);
     }
 }

--- a/src/Responses/MockResponse.php
+++ b/src/Responses/MockResponse.php
@@ -10,22 +10,22 @@ final class MockResponse
      * @param  array<array-key, mixed>  $data
      */
     public function __construct(
-        protected array|DataEntityFactory $data,
+        protected array|DataEntityFactory|\Throwable $data,
     ) {
     }
 
     /**
      * @param  array<array-key, mixed>  $data
      */
-    public static function make(array|DataEntityFactory $data): static
+    public static function make(array|DataEntityFactory|\Throwable $data): static
     {
         return new self($data);
     }
 
     /**
-     * @return array<array-key, mixed>
+     * @return array<array-key, mixed>|\Throwable
      */
-    public function data(): array
+    public function data(): array|\Throwable
     {
         if ($this->data instanceof DataEntityFactory) {
             return $this->data->create();

--- a/src/Traits/DataEntity/ExecutesQuery.php
+++ b/src/Traits/DataEntity/ExecutesQuery.php
@@ -28,9 +28,11 @@ trait ExecutesQuery
     {
         $executer = $this->resolveClient();
 
-        $reponse = $executer->handle();
+        $response = $executer->handle();
 
-        return $reponse;
+        $response->getPendingQuery()->middleware()->executeResponsePipeline($response);
+
+        return $response;
     }
 
     protected function resolveClient(): ProcessorContract

--- a/src/Traits/DataEntity/HasMiddleware.php
+++ b/src/Traits/DataEntity/HasMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace BitMx\DataEntities\Traits\DataEntity;
+
+use BitMx\DataEntities\Pipelines\MiddlewarePipeline;
+
+trait HasMiddleware
+{
+    protected MiddlewarePipeline $middlewarePipeline;
+
+    public function middleware(): MiddlewarePipeline
+    {
+        return $this->middlewarePipeline ??= new MiddlewarePipeline();
+    }
+}

--- a/src/Traits/Response/ThrowsError.php
+++ b/src/Traits/Response/ThrowsError.php
@@ -7,6 +7,11 @@ namespace BitMx\DataEntities\Traits\Response;
  */
 trait ThrowsError
 {
+    public function getError(): ?string
+    {
+        return $this->senderException?->getMessage();
+    }
+
     public function throw(): void
     {
         if ($this->senderException === null) {

--- a/tests/Unit/PendingQueryTest.php
+++ b/tests/Unit/PendingQueryTest.php
@@ -21,5 +21,14 @@ it('creates a PendingQuery', function () {
 
     expect($pendingQuery->getDataEntity())->toBe($this->dataEntity)
         ->and($pendingQuery->getMethod())->toBe(Method::SELECT);
+});
 
+it('executes query middlewares', function () {
+    $this->dataEntity->middleware()->onQuery(function (PendingQuery $pendingQuery) {
+        $pendingQuery->parameters()->add('test', 'test 1');
+    });
+
+    $pendingQuery = new PendingQuery($this->dataEntity);
+
+    expect($pendingQuery->parameters()->all())->toBe(['test' => 'test 1']);
 });

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -266,13 +266,11 @@ it('get value with a custom Accessor', function () {
     };
 
     DataEntity::fake([
-        $dataEntity::class => MockResponse::make([
-            'value' => 'test',
-        ]),
+        $dataEntity::class => MockResponse::make(new \Exception()),
     ]);
 
     $response = $dataEntity->execute();
 
-    expect($response->data('value'))->toBe('TEST');
+    expect($response->data())->toBe([]);
 
 });


### PR DESCRIPTION
Added functionality that allows for middleware execution upon query processing.

Along with, error or exception handling has been improved by allowing \Throwable instances to be returned as responses. This commit also rectifies a minor typo in ExecutesQuery.php. Essential tests were updated to match these changes.
