### PR TITLE
Add support for alias and output parameters in queries

### DIFF
--- a/src/DataEntity.php
+++ b/src/DataEntity.php
@@ -9,11 +9,13 @@ use BitMx\DataEntities\Traits\DataEntity\Assertable;
 use BitMx\DataEntities\Traits\DataEntity\Bootable;
 use BitMx\DataEntities\Traits\DataEntity\ExecutesQuery;
 use BitMx\DataEntities\Traits\DataEntity\HasAccessors;
+use BitMx\DataEntities\Traits\DataEntity\HasAlias;
 use BitMx\DataEntities\Traits\DataEntity\HasConnection;
 use BitMx\DataEntities\Traits\DataEntity\HasDumpableQuery;
 use BitMx\DataEntities\Traits\DataEntity\HasFakeableResponse;
 use BitMx\DataEntities\Traits\DataEntity\HasMiddleware;
 use BitMx\DataEntities\Traits\DataEntity\HasMutators;
+use BitMx\DataEntities\Traits\HasOutputParameters;
 use BitMx\DataEntities\Traits\HasParameters;
 use BitMx\DataEntities\Traits\HasQueryStatements;
 
@@ -23,11 +25,13 @@ abstract class DataEntity
     use Bootable;
     use ExecutesQuery;
     use HasAccessors;
+    use HasAlias;
     use HasConnection;
     use HasDumpableQuery;
     use HasFakeableResponse;
     use HasMiddleware;
     use HasMutators;
+    use HasOutputParameters;
     use HasParameters;
     use HasQueryStatements;
 

--- a/src/PendingQuery.php
+++ b/src/PendingQuery.php
@@ -4,15 +4,19 @@ namespace BitMx\DataEntities;
 
 use BitMx\DataEntities\Enums\Method;
 use BitMx\DataEntities\PendingQuery\AddAccessors;
+use BitMx\DataEntities\PendingQuery\AddAlias;
 use BitMx\DataEntities\PendingQuery\AddMutators;
 use BitMx\DataEntities\PendingQuery\BootDataEntity;
 use BitMx\DataEntities\PendingQuery\BootTraits;
 use BitMx\DataEntities\PendingQuery\MergeMiddlewares;
+use BitMx\DataEntities\PendingQuery\MergeOutputParameters;
 use BitMx\DataEntities\PendingQuery\MergeParameters;
 use BitMx\DataEntities\PendingQuery\MergeQueryStatements;
 use BitMx\DataEntities\Traits\DataEntity\HasAccessors;
+use BitMx\DataEntities\Traits\DataEntity\HasAlias;
 use BitMx\DataEntities\Traits\DataEntity\HasMiddleware;
 use BitMx\DataEntities\Traits\DataEntity\HasMutators;
+use BitMx\DataEntities\Traits\HasOutputParameters;
 use BitMx\DataEntities\Traits\HasParameters;
 use BitMx\DataEntities\Traits\HasQueryStatements;
 use BitMx\DataEntities\Traits\PendingQuery\Tappable;
@@ -20,8 +24,10 @@ use BitMx\DataEntities\Traits\PendingQuery\Tappable;
 class PendingQuery
 {
     use HasAccessors;
+    use HasAlias;
     use HasMiddleware;
     use HasMutators;
+    use HasOutputParameters;
     use HasParameters;
     use HasQueryStatements;
     use Tappable;
@@ -36,10 +42,12 @@ class PendingQuery
             ->tap(new BootDataEntity)
             ->tap(new BootTraits)
             ->tap(new MergeParameters)
+            ->tap(new MergeOutputParameters)
             ->tap(new MergeQueryStatements)
             ->tap(new MergeMiddlewares)
             ->tap(new AddMutators)
-            ->tap(new AddAccessors);
+            ->tap(new AddAccessors)
+            ->tap(new AddAlias);
 
         // Execute the middleware
         $this->middleware()->executeQueryPipeline($this);

--- a/src/PendingQuery/AddAlias.php
+++ b/src/PendingQuery/AddAlias.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace BitMx\DataEntities\PendingQuery;
+
+use BitMx\DataEntities\PendingQuery;
+
+readonly class AddAlias
+{
+    public function __invoke(PendingQuery $pendingQuery): PendingQuery
+    {
+        $pendingQuery->setAlias($pendingQuery->getDataEntity()->getalias());
+
+        return $pendingQuery;
+    }
+}

--- a/src/PendingQuery/MergeOutputParameters.php
+++ b/src/PendingQuery/MergeOutputParameters.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BitMx\DataEntities\PendingQuery;
+
+use BitMx\DataEntities\PendingQuery;
+
+readonly class MergeOutputParameters
+{
+    public function __invoke(PendingQuery $pendingQuery): PendingQuery
+    {
+        $dataEntity = $pendingQuery->getDataEntity();
+
+        $outputParameters = $dataEntity->outputParameters()->all();
+
+        $pendingQuery->outputParameters()->merge($outputParameters);
+
+        return $pendingQuery;
+    }
+}

--- a/src/Processors/Processor.php
+++ b/src/Processors/Processor.php
@@ -46,6 +46,7 @@ class Processor implements ProcessorContract
 
         try {
             $executionMethod = $this->getExecuter();
+
             $preparedQuery = $this->prepareQuery();
 
             $params = $this->createParameters();
@@ -70,7 +71,7 @@ class Processor implements ProcessorContract
     protected function getExecuter(): string
     {
         return match ($this->pendingQuery->getMethod()) {
-            Method::SELECT => 'select',
+            Method::SELECT => 'selectResultSets',
             Method::STATEMENT => 'statement',
         };
     }

--- a/src/Responses/Response.php
+++ b/src/Responses/Response.php
@@ -14,14 +14,112 @@ readonly class Response
     use ThrowsError;
 
     /**
+     * @var array<array-key, mixed>
+     */
+    protected array $data;
+
+    /**
+     * @var array<array-key, mixed>
+     */
+    protected array $output;
+
+    /**
      * @param  array<array-key, mixed>  $data
      */
     public function __construct(
         protected PendingQuery $pendingQuery,
-        protected array $data = [],
+        array $data = [],
         protected bool $success = true,
         protected ?\Throwable $senderException = null
     ) {
+        $this->data = $this->getData($data);
+
+        $this->output = $this->getOutput($data);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @return array<array-key, mixed>
+     */
+    protected function getData(array $data): array
+    {
+        $outputParametersCount = $this->pendingQuery->outputParameters()->toCollection()->count();
+
+        if ($outputParametersCount === 0) {
+            return $data;
+        }
+
+        return $data[0];
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @return array<array-key, mixed>
+     */
+    protected function getOutput(array $data): array
+    {
+        $outputParametersCount = $this->pendingQuery->outputParameters()->toCollection()->count();
+
+        if ($outputParametersCount === 0) {
+            return [];
+        }
+
+        return collect($data)
+            ->filter(fn (array $value, int $key): bool => $key > 0)
+            ->flatMap(fn (array $value): array => $value[0])
+            ->mapWithKeys(fn (mixed $value, string $key): array => [$this->getAliasOutputParameter($key) => $value])
+            ->all();
+    }
+
+    protected function getAliasOutputParameter(string $parameter): string
+    {
+        if ($this->pendingQuery->outputParameters()->isEmpty()) {
+            return $parameter;
+        }
+
+        if (empty($this->pendingQuery->getalias())) {
+            return $parameter;
+        }
+
+        return $this->pendingQuery->getalias()[$parameter] ?? $parameter;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->data());
+    }
+
+    /**
+     * @param  ?array-key  $key
+     * @return ($key is null ? array<array-key, mixed> : mixed)
+     */
+    public function data(string|int|null $key = null, mixed $default = null): mixed
+    {
+        $data = $this->mutatedData($this->rawData());
+
+        if (is_null($key)) {
+            return $data;
+        }
+
+        return Arr::get($data, $key, $default);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @return array<array-key, mixed>
+     */
+    protected function mutatedData(array $data): array
+    {
+        return AccessorProcessor::make($data, $this->pendingQuery)->process();
+    }
+
+    public function rawData(?string $key = null): mixed
+    {
+        if (is_null($key)) {
+            return $this->data;
+        }
+
+        return Arr::get($this->data, $key);
     }
 
     public function failed(): bool
@@ -39,18 +137,13 @@ readonly class Response
         return ! $this->isEmpty();
     }
 
-    public function isEmpty(): bool
-    {
-        return empty($this->data());
-    }
-
     /**
      * @param  ?array-key  $key
      * @return ($key is null ? array<array-key, mixed> : mixed)
      */
-    public function data(string|int|null $key = null, mixed $default = null): mixed
+    public function output(string|int|null $key = null, mixed $default = null): mixed
     {
-        $data = $this->mutatedData();
+        $data = $this->mutatedData($this->rawOutput());
 
         if (is_null($key)) {
             return $data;
@@ -59,21 +152,13 @@ readonly class Response
         return Arr::get($data, $key, $default);
     }
 
-    /**
-     * @return array<array-key, mixed>
-     */
-    protected function mutatedData(): array
-    {
-        return AccessorProcessor::make($this->rawData(), $this->pendingQuery)->process();
-    }
-
-    public function rawData(?string $key = null): mixed
+    public function rawOutput(?string $key = null): mixed
     {
         if (is_null($key)) {
-            return $this->data;
+            return $this->output;
         }
 
-        return $this->data[$key];
+        return Arr::get($this->output, $key);
     }
 
     public function object(): object
@@ -107,5 +192,13 @@ readonly class Response
     public function getPendingQuery(): PendingQuery
     {
         return $this->pendingQuery;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function outputKeys(): array
+    {
+        return $this->pendingQuery->outputParameters()->toCollection()->keys()->toArray();
     }
 }

--- a/src/Traits/DataEntity/HasAlias.php
+++ b/src/Traits/DataEntity/HasAlias.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BitMx\DataEntities\Traits\DataEntity;
+
+trait HasAlias
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $alias = [];
+
+    /**
+     * @return array<string, string>
+     */
+    public function getalias(): array
+    {
+        return $this->mergeAlias();
+    }
+
+    /**
+     * @param  array<string, string>  $alias
+     */
+    public function setAlias(array $alias): void
+    {
+        $this->alias = $alias;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function mergeAlias(): array
+    {
+        return array_merge($this->alias(), $this->alias);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function alias(): array
+    {
+        return [];
+    }
+}

--- a/src/Traits/Executer/HasQuery.php
+++ b/src/Traits/Executer/HasQuery.php
@@ -11,14 +11,57 @@ trait HasQuery
     {
         $storeProcedure = $this->pendingQuery->statements()->toCollection()->join('; ');
 
+        $storeProcedure = (string) str(sprintf(
+            '%s %s',
+            $this->prependOutputParametersStatements(),
+            $storeProcedure,
+        ))
+            ->trim();
+
         $keys = $this->pendingQuery->parameters()->keys();
 
-        $exec = $storeProcedure;
+        $exec = $storeProcedure.' ';
 
-        $exec .= $keys->map(fn (string $key) => sprintf('@%s = :%s', $key, $key))->implode(', ');
+        $params = $keys->map(fn (string $key) => sprintf('@%s = :%s', $key, $key));
+
+        $outputParams = $this->pendingQuery->outputParameters()->keys()->map(fn (string $key) => sprintf('@%s = @%s OUTPUT', $key, $key));
+
+        $exec .= $params->merge($outputParams)->implode(', ');
 
         $exec .= ';';
 
+        $exec = sprintf(
+            '%s %s',
+            $exec,
+            $this->appendOutputParametersStatements(),
+        );
+
         return $exec;
+    }
+
+    protected function prependOutputParametersStatements(): string
+    {
+        if ($this->pendingQuery->outputParameters()->isEmpty()) {
+            return '';
+        }
+
+        $outputParameters = $this->pendingQuery->outputParameters()->toCollection();
+
+        return $outputParameters->map(function (string $value, string $key) {
+            return sprintf('DECLARE @%s %s;', $key, $value);
+        })->implode("\n");
+    }
+
+    protected function appendOutputParametersStatements(): string
+    {
+        if ($this->pendingQuery->outputParameters()->isEmpty()) {
+            return '';
+        }
+
+        $outputParameters = $this->pendingQuery->outputParameters()->toCollection();
+
+        return $outputParameters->map(function (string $value, string $key) {
+            return sprintf('SELECT @%s AS %s;', $key, $key);
+        })->implode("\n");
     }
 }

--- a/src/Traits/HasOutputParameters.php
+++ b/src/Traits/HasOutputParameters.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BitMx\DataEntities\Traits;
+
+use BitMx\DataEntities\Stores\ParameterStore;
+
+trait HasOutputParameters
+{
+    public ParameterStore $outputParameters;
+
+    public function outputParameters(): ParameterStore
+    {
+        return $this->outputParameters ??= new ParameterStore($this->defaultOutputParameters());
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function defaultOutputParameters(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
This update introduces new methods and traits to handle alias and output parameters in queries. A new trait `HasAlias` has been introduced to support aliases in query parameters. Moreover, support for output parameters in queries has been added using the `HasOutputParameters` trait. Changes have been made in `PendingQuery`, `DataEntity`, `HasQuery` and `Response` classes to incorporate this new functionality.
