### PR TITLE
Add AlwaysThrowOnError plugin and tests

### DIFF
--- a/src/Plugins/AlwaysThrowOnError.php
+++ b/src/Plugins/AlwaysThrowOnError.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BitMx\DataEntities\Plugins;
+
+use BitMx\DataEntities\DataEntity;
+use BitMx\DataEntities\Responses\Response;
+
+/**
+ * @mixin DataEntity
+ */
+trait AlwaysThrowOnError
+{
+    public function bootAlwaysThrowOnError(): void
+    {
+        $this->middleware()->onResponse(function (Response $response) {
+            $response->throw();
+        });
+    }
+}

--- a/tests/Unit/Plugins/AlwaysThrowOnErrorTest.php
+++ b/tests/Unit/Plugins/AlwaysThrowOnErrorTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use BitMx\DataEntities\DataEntity;
+use BitMx\DataEntities\Enums\Method;
+use BitMx\DataEntities\Enums\ResponseType;
+
+it('throw error on response', function () {
+    $dataEntity = new class extends DataEntity
+    {
+        protected ?Method $method = Method::SELECT;
+
+        protected ?ResponseType $responseType = ResponseType::SINGLE;
+
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+    };
+});


### PR DESCRIPTION
A new plugin called AlwaysThrowOnError was implemented into BitMx/DataEntities. This addition provides functionality to always throw an error on a response, increasing the robustness of error handling. Accompanying unit tests ensure its correct operation.
