### PR TITLE
Add HasAccessorsStore and HasMutatorStore traits

### DIFF
--- a/src/Parameters/ParametersProcessor.php
+++ b/src/Parameters/ParametersProcessor.php
@@ -30,6 +30,6 @@ class ParametersProcessor
      */
     protected function processParameterValue(mixed $value, string $key, array $parameters): string|int|bool|float|null
     {
-        return Transformer::make($value, $key, $this->pendingQuery->getMutators(), $parameters)->transform();
+        return Transformer::make($value, $key, $this->pendingQuery->mutators()->all(), $parameters)->transform();
     }
 }

--- a/src/PendingQuery.php
+++ b/src/PendingQuery.php
@@ -12,21 +12,21 @@ use BitMx\DataEntities\PendingQuery\MergeMiddlewares;
 use BitMx\DataEntities\PendingQuery\MergeOutputParameters;
 use BitMx\DataEntities\PendingQuery\MergeParameters;
 use BitMx\DataEntities\PendingQuery\MergeQueryStatements;
-use BitMx\DataEntities\Traits\DataEntity\HasAccessors;
 use BitMx\DataEntities\Traits\DataEntity\HasAlias;
 use BitMx\DataEntities\Traits\DataEntity\HasMiddleware;
-use BitMx\DataEntities\Traits\DataEntity\HasMutators;
 use BitMx\DataEntities\Traits\HasOutputParameters;
 use BitMx\DataEntities\Traits\HasParameters;
 use BitMx\DataEntities\Traits\HasQueryStatements;
+use BitMx\DataEntities\Traits\PendingQuery\HasAccessorsStore;
+use BitMx\DataEntities\Traits\PendingQuery\HasMutatorStore;
 use BitMx\DataEntities\Traits\PendingQuery\Tappable;
 
 class PendingQuery
 {
-    use HasAccessors;
+    use HasAccessorsStore;
     use HasAlias;
     use HasMiddleware;
-    use HasMutators;
+    use HasMutatorStore;
     use HasOutputParameters;
     use HasParameters;
     use HasQueryStatements;

--- a/src/PendingQuery/AddAccessors.php
+++ b/src/PendingQuery/AddAccessors.php
@@ -8,7 +8,7 @@ readonly class AddAccessors
 {
     public function __invoke(PendingQuery $pendingQuery): PendingQuery
     {
-        $pendingQuery->setAccessors($pendingQuery->getDataEntity()->getAccessors());
+        $pendingQuery->accessors()->merge($pendingQuery->getDataEntity()->getAccessors());
 
         return $pendingQuery;
     }

--- a/src/PendingQuery/AddMutators.php
+++ b/src/PendingQuery/AddMutators.php
@@ -8,7 +8,7 @@ readonly class AddMutators
 {
     public function __invoke(PendingQuery $pendingQuery): PendingQuery
     {
-        $pendingQuery->setMutators($pendingQuery->getDataEntity()->getMutators());
+        $pendingQuery->mutators()->merge($pendingQuery->getDataEntity()->getMutators());
 
         return $pendingQuery;
     }

--- a/src/Responses/Mutators/AccessorProcessor.php
+++ b/src/Responses/Mutators/AccessorProcessor.php
@@ -43,7 +43,7 @@ final readonly class AccessorProcessor
     {
         return array_merge(
             AccessorsAlias::get(),
-            $this->pendingQuery->getAccessors()
+            $this->pendingQuery->accessors()->all()
         );
     }
 }

--- a/src/Traits/HasParameters.php
+++ b/src/Traits/HasParameters.php
@@ -6,7 +6,7 @@ use BitMx\DataEntities\Stores\ParameterStore;
 
 trait HasParameters
 {
-    public ParameterStore $parameters;
+    protected ParameterStore $parameters;
 
     public function parameters(): ParameterStore
     {

--- a/src/Traits/PendingQuery/HasAccessorsStore.php
+++ b/src/Traits/PendingQuery/HasAccessorsStore.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BitMx\DataEntities\Traits\PendingQuery;
+
+use BitMx\DataEntities\Stores\ParameterStore;
+
+/**
+ * @mixin \BitMx\DataEntities\PendingQuery
+ */
+trait HasAccessorsStore
+{
+    protected ParameterStore $accessors;
+
+    public function accessors(): ParameterStore
+    {
+        return $this->accessors ??= new ParameterStore();
+    }
+}

--- a/src/Traits/PendingQuery/HasMutatorStore.php
+++ b/src/Traits/PendingQuery/HasMutatorStore.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BitMx\DataEntities\Traits\PendingQuery;
+
+use BitMx\DataEntities\Stores\ParameterStore;
+
+/**
+ * @mixin \BitMx\DataEntities\PendingQuery
+ */
+trait HasMutatorStore
+{
+    protected ParameterStore $mutators;
+
+    public function mutators(): ParameterStore
+    {
+        return $this->mutators ??= new ParameterStore();
+    }
+}


### PR DESCRIPTION
The commit includes the creation of the HasAccessorsStore and HasMutatorStore traits which contain protected properties for accessor and mutator stores as well as methods to manipulate them. These traits have been now used in the PendingQuery class replacing the older HasAccessors and HasMutators traits.
