### PR TITLE
Add array handling to ArrayStore add method

### DIFF
--- a/src/Contracts/DataStore.php
+++ b/src/Contracts/DataStore.php
@@ -20,7 +20,10 @@ interface DataStore
 
     public function isNotEmpty(): bool;
 
-    public function add(): self;
+    /**
+     * @param  string|int|array<array-key, mixed>|null  $key
+     */
+    public function add(string|int|array|null $key = null, mixed $value = null): self;
 
     /**
      * @param  array<array-key, mixed>  ...$arrays

--- a/src/Stores/ArrayStore.php
+++ b/src/Stores/ArrayStore.php
@@ -59,8 +59,17 @@ class ArrayStore implements DataStore
         return empty($this->data);
     }
 
-    public function add(string|int|null $key = null, mixed $value = null): self
+    /**
+     * @param  string|int|array<array-key, mixed>|null  $key
+     */
+    public function add(string|int|array|null $key = null, mixed $value = null): self
     {
+        if (is_array($key)) {
+            $this->data = array_merge($this->data, $key);
+
+            return $this;
+        }
+
         isset($key)
             ? $this->data[$key] = $value
             : $this->data[] = $value;


### PR DESCRIPTION
The add method in ArrayStore and DataStore contract has been updated to allow handling of arrays. This change allows merging of an input array into the existing data, providing additional flexibility in data management. The method signature and related comments have been adjusted accordingly.
