### PR TITLE
Update MockResponse handling and add HasMutatedData trait

### DIFF
--- a/src/DataEntity.php
+++ b/src/DataEntity.php
@@ -35,7 +35,7 @@ abstract class DataEntity
     use HasParameters;
     use HasQueryStatements;
 
-    protected ?Method $method = null;
+    protected ?Method $method = Method::SELECT;
 
     protected ?ResponseType $responseType = null;
 

--- a/src/Factories/DataEntityFactory.php
+++ b/src/Factories/DataEntityFactory.php
@@ -75,6 +75,7 @@ abstract class DataEntityFactory
             $this->definition(),
             $this->attributes,
             $this->without,
+            $this->output()
         );
     }
 
@@ -82,6 +83,14 @@ abstract class DataEntityFactory
      * @return array<array-key, mixed>
      */
     abstract public function definition(): array;
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function output(): array
+    {
+        return [];
+    }
 
     /**
      * @param  array<array-key, mixed>|string  $attributes

--- a/src/Factories/FactoryData.php
+++ b/src/Factories/FactoryData.php
@@ -8,11 +8,13 @@ readonly class FactoryData
      * @param  array<array-key, mixed>  $definition
      * @param  array<array-key, mixed>  $attributes
      * @param  array<array-key, mixed>  $without
+     * @param  array<array-key, mixed>  $output
      */
     public function __construct(
         private array $definition,
         private array $attributes,
         private array $without,
+        private array $output,
     ) {
     }
 
@@ -40,5 +42,13 @@ readonly class FactoryData
     public function getWithout(): array
     {
         return $this->without;
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function getOutput(): array
+    {
+        return $this->output;
     }
 }

--- a/src/Processors/MockProcessor.php
+++ b/src/Processors/MockProcessor.php
@@ -47,8 +47,8 @@ class MockProcessor implements ProcessorContract
     protected function createFakeResponse(MockResponse $mockResponse): Response
     {
 
-        if ($mockResponse->data() instanceof \Throwable) {
-            return new Response($this->pendingQuery, [], false, $mockResponse->data());
+        if ($mockResponse->hasException()) {
+            return new Response($this->pendingQuery, [], false, $mockResponse->exception());
         }
 
         return new Response($this->pendingQuery, $mockResponse->data(), true);

--- a/src/Responses/MockResponse.php
+++ b/src/Responses/MockResponse.php
@@ -15,6 +15,7 @@ final readonly class MockResponse
         protected array $output = [],
         protected ?\Throwable $exception = null
     ) {
+
     }
 
     /**
@@ -35,7 +36,31 @@ final readonly class MockResponse
      */
     public function data(): array
     {
-        return array_merge($this->getData(), $this->output);
+        if (empty($this->getOutput())) {
+            return $this->getData();
+        }
+
+        return [
+            $this->getData(),
+            $this->getOutput(),
+        ];
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function getOutput(): array
+    {
+
+        $output = $this->data instanceof DataEntityFactory
+            ? array_replace_recursive($this->data->getData()->getOutput(), $this->output)
+            : $this->output;
+
+        if (empty($output)) {
+            return [];
+        }
+
+        return [$output];
     }
 
     /**

--- a/src/Responses/MockResponse.php
+++ b/src/Responses/MockResponse.php
@@ -4,33 +4,59 @@ namespace BitMx\DataEntities\Responses;
 
 use BitMx\DataEntities\Factories\DataEntityFactory;
 
-final class MockResponse
+final readonly class MockResponse
 {
     /**
      * @param  array<array-key, mixed>  $data
+     * @param  array<array-key, mixed>  $output
      */
     public function __construct(
-        protected array|DataEntityFactory|\Throwable $data,
+        protected array|DataEntityFactory $data,
+        protected array $output = [],
+        protected ?\Throwable $exception = null
     ) {
     }
 
     /**
      * @param  array<array-key, mixed>  $data
      */
-    public static function make(array|DataEntityFactory|\Throwable $data): static
+    public static function make(array|DataEntityFactory $data): self
     {
         return new self($data);
     }
 
+    public static function makeWithException(\Throwable $exception): self
+    {
+        return new self([], [], $exception);
+    }
+
     /**
-     * @return array<array-key, mixed>|\Throwable
+     * @return array<array-key, mixed>
      */
-    public function data(): array|\Throwable
+    public function data(): array
+    {
+        return array_merge($this->getData(), $this->output);
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function getData(): array
     {
         if ($this->data instanceof DataEntityFactory) {
             return $this->data->create();
         }
 
         return $this->data;
+    }
+
+    public function hasException(): bool
+    {
+        return $this->exception !== null;
+    }
+
+    public function exception(): ?\Throwable
+    {
+        return $this->exception;
     }
 }

--- a/src/Stores/ArrayStore.php
+++ b/src/Stores/ArrayStore.php
@@ -33,9 +33,9 @@ class ArrayStore implements DataStore
     }
 
     #[\Override]
-    public function get(string $key): mixed
+    public function get(string $key, mixed $default = null): mixed
     {
-        return Arr::get($this->data, $key);
+        return Arr::get($this->data, $key, $default);
     }
 
     /**

--- a/src/Traits/Response/HasMutatedData.php
+++ b/src/Traits/Response/HasMutatedData.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace BitMx\DataEntities\Traits\Response;
+
+use BitMx\DataEntities\Enums\ResponseType;
+use BitMx\DataEntities\Responses\Mutators\AccessorProcessor;
+use BitMx\DataEntities\Responses\Response;
+
+/**
+ * @mixin Response
+ */
+trait HasMutatedData
+{
+    /**
+     * @var array<array-key, mixed>
+     */
+    protected array $mutatedData;
+
+    /**
+     * @var array<array-key, mixed>
+     */
+    protected array $aliasData;
+
+    /**
+     * @var array<array-key, mixed>
+     */
+    protected array $aliasOutput;
+
+    /**
+     * @var array<array-key, mixed>
+     */
+    protected array $mutatedOutput;
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function mutatedData(): array
+    {
+        return $this->mutatedData ??= $this->getMutatedData();
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function getMutatedData(): array
+    {
+        if ($this->getDataEntity()->getResponseType() === ResponseType::SINGLE) {
+            return $this->mutateSingleData($this->aliasData());
+        }
+
+        return $this->mutateCollectionData($this->aliasData());
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @return array<array-key, mixed>
+     */
+    protected function mutateSingleData(array $data): array
+    {
+        return $this->mutateResponse($data);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @return array<array-key, mixed>
+     */
+    protected function mutateResponse(array $data): array
+    {
+        if ($this->pendingQuery->accessors()->isEmpty()) {
+            return $data;
+        }
+
+        return AccessorProcessor::make($data, $this->pendingQuery)->process();
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function aliasData(): array
+    {
+        return $this->aliasData ??= $this->getAliasData();
+
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function getAliasData(): array
+    {
+        return $this->getDataEntity()->getResponseType() === ResponseType::SINGLE
+            ? $this->aliasSingleData()
+            : $this->aliasCollectionData();
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function aliasSingleData(): array
+    {
+        return $this->aliasResponse($this->rawData());
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @return array<array-key, mixed>
+     */
+    protected function aliasResponse(array $data = []): array
+    {
+        if ($this->pendingQuery->alias()->isEmpty()) {
+            return $data;
+        }
+
+        if (empty($data)) {
+            return [];
+        }
+
+        return collect($data)
+            ->mapWithKeys(fn (mixed $value, string $key): array => [$this->getParameterAlias($key) => $value])
+            ->all();
+    }
+
+    protected function getParameterAlias(string $parameter): string
+    {
+        return $this->pendingQuery->alias()->get($parameter, $parameter);
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function aliasCollectionData(): array
+    {
+        return collect($this->rawData())
+            ->map(fn (array $value): array => $this->aliasResponse($value))
+            ->all();
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     * @return array<array-key, mixed>
+     */
+    protected function mutateCollectionData(array $data): array
+    {
+        return collect($data)
+            ->map(fn (mixed $value): array => $this->mutateSingleData($value))
+            ->all();
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function mutatedOutput(): array
+    {
+        return $this->mutatedOutput ??= $this->mutateResponse($this->aliasOutput());
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function aliasOutput(): array
+    {
+        return $this->aliasOutput ??= $this->aliasResponse($this->rawOutput());
+    }
+}

--- a/stubs/data-entity.stub
+++ b/stubs/data-entity.stub
@@ -8,8 +8,6 @@ use BitMx\DataEntities\Enums\ResponseType;
 
 class {{ class }} extends DataEntity
 {
-    protected ?Method $method = Method::SELECT;
-
     protected ?ResponseType $responseType = ResponseType::SINGLE;
 
     #[\Override]

--- a/tests/Unit/DataEntityTest.php
+++ b/tests/Unit/DataEntityTest.php
@@ -58,7 +58,7 @@ test('if fake is enabled fake then DataEntity is fakeable', function () {
     };
 
     DataEntity::fake([
-        $dataEntity::class => MockResponse::make(new Exception('Error')),
+        $dataEntity::class => MockResponse::makeWithException(new Exception('Error')),
     ]);
 
     $dataEntity->execute();

--- a/tests/Unit/Factories/FactoryDataTest.php
+++ b/tests/Unit/Factories/FactoryDataTest.php
@@ -7,6 +7,7 @@ test('creates a new instance of FactoryData', function () {
         definition: ['name' => 'John Doe'],
         attributes: ['email' => 'test@example.com', 'name' => 'Jane Doe'],
         without: ['name'],
+        output: [],
     );
 
     expect($factoryData)->toBeInstanceOf(FactoryData::class);
@@ -17,6 +18,7 @@ it('gets the data merged between definition and attributes', function () {
         definition: ['name' => 'John Doe'],
         attributes: ['email' => 'test@example.com', 'name' => 'Jane Doe'],
         without: [],
+        output: [],
     );
 
     expect($factoryData->getData())->toBe([
@@ -30,6 +32,7 @@ it('get the data without the specified keys', function () {
         definition: ['name' => 'John Doe'],
         attributes: ['email' => 'test@example.com', 'name' => 'Jane Doe'],
         without: ['name'],
+        output: [],
     );
 
     expect($factoryData->getData())->toBe([


### PR DESCRIPTION
Updated MockResponse to handle exceptions separately and added HasMutatedData trait to Response. The method in DataEntity instances has been set to SELECT by default and processing mutators has been moved from Response to AccessorProcessor. Made the class property on MockResponse and PendingQuery in Response read-only for better immutability.
