### PR TITLE
Add support for single response type

### DIFF
--- a/src/Processors/MockProcessor.php
+++ b/src/Processors/MockProcessor.php
@@ -4,6 +4,7 @@ namespace BitMx\DataEntities\Processors;
 
 use BitMx\DataEntities\Contracts\ProcessorContract;
 use BitMx\DataEntities\DataEntity;
+use BitMx\DataEntities\Enums\ResponseType;
 use BitMx\DataEntities\Exceptions\MockResponseNotFoundException;
 use BitMx\DataEntities\PendingQuery;
 use BitMx\DataEntities\Responses\MockResponse;
@@ -49,6 +50,10 @@ class MockProcessor implements ProcessorContract
 
         if ($mockResponse->hasException()) {
             return new Response($this->pendingQuery, [], false, $mockResponse->exception());
+        }
+
+        if ($this->dataEntity->getResponseType() === ResponseType::SINGLE) {
+            return new Response($this->pendingQuery, $mockResponse->data()[0], true);
         }
 
         return new Response($this->pendingQuery, $mockResponse->data(), true);

--- a/src/Responses/Response.php
+++ b/src/Responses/Response.php
@@ -3,6 +3,7 @@
 namespace BitMx\DataEntities\Responses;
 
 use BitMx\DataEntities\DataEntity;
+use BitMx\DataEntities\Enums\ResponseType;
 use BitMx\DataEntities\PendingQuery;
 use BitMx\DataEntities\Traits\Response\HasMutatedData;
 use BitMx\DataEntities\Traits\Response\ThrowsError;
@@ -44,7 +45,16 @@ class Response
      */
     protected function getData(array $data): array
     {
+        if ($this->getDataEntity()->getResponseType() === ResponseType::SINGLE) {
+            return $data;
+        }
+
         return Arr::get($data, '0', []);
+    }
+
+    public function getDataEntity(): DataEntity
+    {
+        return $this->pendingQuery->getDataEntity();
     }
 
     /**
@@ -158,11 +168,6 @@ class Response
             ->createDtoFromResponse(
                 $this
             );
-    }
-
-    public function getDataEntity(): DataEntity
-    {
-        return $this->pendingQuery->getDataEntity();
     }
 
     public function getPendingQuery(): PendingQuery


### PR DESCRIPTION
The code has been updated to handle the case where the response type is a single entity. Changes were made in 'MockProcessor.php' and 'Response.php' files to enable fetching and processing of data accordingly, when the response type is set to 'SINGLE'. Any related method calling and data handling were also adjusted for this response type.
