### PR TITLE
Allow dynamic Connection instances via resolve and onConnection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,12 @@ php artisan data-entities:check
 
 ### Connection
 
-You can set the connection name by overriding the `resolveDatabaseConnection` method.
+You can set the connection by overriding `resolveDatabaseConnection()`. It may return a Laravel
+connection **name** (`string`) or a live `Illuminate\Database\Connection` instance.
+
+Precedence when executing:
+
+`onConnection(...)` → `resolveDatabaseConnection()` → `config('data-entities.database')`
 
 ```php
 namespace App\DataEntities;
@@ -259,7 +264,7 @@ class GetAllPostsDataEntity extends DataEntity
     // ...
 
     #[\Override]
-    public function resolveDatabaseConnection(): string
+    public function resolveDatabaseConnection(): string|\Illuminate\Database\Connection
     {
         return 'sqlsrv';
     }
@@ -276,7 +281,7 @@ use BitMx\DataEntities\DataEntity;
 abstract class ErpDataEntity extends DataEntity
 {
     #[\Override]
-    public function resolveDatabaseConnection(): string
+    public function resolveDatabaseConnection(): string|\Illuminate\Database\Connection
     {
         return 'erp_sqlsrv';
     }
@@ -299,12 +304,57 @@ use BitMx\DataEntities\DataEntity;
 abstract class CrmDataEntity extends DataEntity
 {
     #[\Override]
-    public function resolveDatabaseConnection(): string
+    public function resolveDatabaseConnection(): string|\Illuminate\Database\Connection
     {
         return 'crm_mysql';
     }
 }
 ```
+
+For a connection that is **not** defined in `config/database.php`, build one at runtime with
+Laravel's `DB::build()` (Laravel 11.31+) and return or pass the `Connection` instance.
+Credentials come from your own values (host, user, password, etc.), not from a named config entry:
+
+```php
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\DB;
+
+#[\Override]
+public function resolveDatabaseConnection(): string|Connection
+{
+    return DB::build([
+        'driver' => 'sqlsrv',
+        'host' => $this->host,
+        'port' => $this->port,
+        'database' => $this->database,
+        'username' => $this->username,
+        'password' => $this->password,
+    ]);
+}
+```
+
+Or override the connection at runtime without changing the entity class:
+
+```php
+use Illuminate\Support\Facades\DB;
+
+(new GetCustomerDataEntity($id))
+    ->onConnection(DB::build([
+        'driver' => 'mysql',
+        'host' => $host,
+        'database' => $database,
+        'username' => $user,
+        'password' => $password,
+    ]))
+    ->execute();
+
+(new GetCustomerDataEntity($id))
+    ->onConnection('tenant_mysql') // connection name from config/database.php
+    ->execute();
+```
+
+If the connection is already registered under a name (for example `tenant_123`), you can still use
+`DB::connection('tenant_123')` or `onConnection('tenant_123')` as before.
 
 Organize classes under `app/DataEntities/{System}/` and point `data-entities:list` / `data-entities:check` at those paths with `--path=app/DataEntities/Erp`.
 
@@ -332,13 +382,17 @@ DB::connection('sqlsrv')->transaction(function () {
 });
 ```
 
-Or use the helper (defaults to `config('data-entities.database')`):
+Or use the helper (defaults to `config('data-entities.database')`). The second argument accepts a connection name or a `Connection` instance:
 
 ```php
 DataEntity::transaction(function () {
     (new CreateOrderDataEntity($payload))->execute();
     (new ReserveInventoryDataEntity($orderId))->execute();
 }, connection: 'sqlsrv');
+
+DataEntity::transaction(function () {
+    (new CreateOrderDataEntity($payload))->execute();
+}, connection: $dynamicConnection);
 ```
 
 Entities that target different connections cannot share one transaction.

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -7,6 +7,9 @@
 - Put Data Entity classes in `app/DataEntities` (optionally `app/DataEntities/{System}/` per legacy system).
 - Extend `BitMx\DataEntities\DataEntity` and implement `resolveStoreProcedure(): string`.
 - For multi-system apps, create an abstract base per system (`ErpDataEntity`, `CrmDataEntity`) that fixes `resolveDatabaseConnection()` (and executor if needed); concrete entities extend that base.
+- `resolveDatabaseConnection()` may return a connection name (`string`) or a live `Illuminate\Database\Connection`. Precedence: `onConnection(...)` > `resolveDatabaseConnection()` > `config('data-entities.database')`.
+- Override at runtime with `->onConnection($nameOrConnection)->execute()`.
+- For ad-hoc credentials (host/user/password without `config/database.php`), use `DB::build([...])` and return or `onConnection()` that `Connection`.
 - Override `defaultParameters(): array` (protected) for input parameters.
 - Default response shape is a collection. Use `#[SingleItemResponse]` for a single row.
 - Do NOT use removed v3 APIs: `$method`, `$responseType`, or `BitMx\DataEntities\Enums\Method`.
@@ -82,7 +85,7 @@ DataEntity::recorded(GetPostDataEntity::class);
 - Map rows to DTOs with `#[MapTo(PostData::class)]` (single) or `#[MapTo(PostData::class, Collection::class)]` (Laravel collection); read via `$response->dto()`. Manual `createDtoFromResponse()` always wins over `#[MapTo]`.
 - Use `defaultOutputParameters()` for stored procedure output params; read them with `$response->output()`. On SQL Server they map to `DECLARE`/`OUTPUT`; on MySQL they map to session variables (the declared SQL type is ignored).
 - Override `resolveQueryExecutor(): ?string` on a Data Entity to force a specific query executor; otherwise it is resolved from the connection driver.
-- For multi-entity atomic work on one connection, use `DataEntity::transaction(fn () => ..., connection: 'sqlsrv')` or `DB::connection(...)->transaction(...)`.
+- For multi-entity atomic work on one connection, use `DataEntity::transaction(fn () => ..., connection: 'sqlsrv')`, pass a `Connection` instance, or `DB::connection(...)->transaction(...)`.
 - Use `AlwaysThrowOnError` when failures should throw automatically.
 - For caching, implement `Cacheable` and use the `HasCache` trait; call `invalidateCache()` / `disableCaching()` on the Data Entity instance, not on the Response.
 - For transient DB failures (deadlocks/timeouts), use the `HasRetries` plugin; override `retryBackoff()` with a `CarbonInterval` (or ms int).

--- a/resources/boost/skills/data-entities-development/SKILL.md
+++ b/resources/boost/skills/data-entities-development/SKILL.md
@@ -82,11 +82,12 @@ When the app talks to multiple stored-procedure backends, fix connection (and op
 namespace App\DataEntities\Erp;
 
 use BitMx\DataEntities\DataEntity;
+use Illuminate\Database\Connection;
 
 abstract class ErpDataEntity extends DataEntity
 {
     #[\Override]
-    public function resolveDatabaseConnection(): string
+    public function resolveDatabaseConnection(): string|Connection
     {
         return 'erp_sqlsrv';
     }
@@ -102,9 +103,45 @@ class GetCustomerDataEntity extends ErpDataEntity
 ```
 
 Keep CRM/ERP/etc. entities under `app/DataEntities/{System}/`. Scan a system with `php artisan data-entities:check --path=app/DataEntities/Erp`.
-- Override connection with `resolveDatabaseConnection(): string` when needed.
+
+### Connection resolution
+
+Precedence: `onConnection(...)` > `resolveDatabaseConnection()` > `config('data-entities.database')`.
+
+- Override with `resolveDatabaseConnection(): string|Connection` — return a Laravel connection name or a live `Connection`.
+- Override at runtime: `->onConnection($nameOrConnection)->execute()`.
+- For credentials that are **not** in `config/database.php`, build a connection with `DB::build()` (Laravel 11.31+) and return/`onConnection` it.
 - Override `resolveQueryExecutor(): ?string` to force a specific query executor (default `null` resolves it from the connection driver).
 - Runtime params: `$entity->parameters()->add('key', $value)`.
+
+```php
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\DB;
+
+// Ad-hoc Connection from resolve (no named config entry required)
+public function resolveDatabaseConnection(): string|Connection
+{
+    return DB::build([
+        'driver' => 'sqlsrv',
+        'host' => $this->host,
+        'port' => $this->port,
+        'database' => $this->database,
+        'username' => $this->username,
+        'password' => $this->password,
+    ]);
+}
+
+// Runtime override with DB::build
+(new GetCustomerDataEntity($id))
+    ->onConnection(DB::build([
+        'driver' => 'mysql',
+        'host' => $host,
+        'database' => $database,
+        'username' => $user,
+        'password' => $password,
+    ]))
+    ->execute();
+```
 
 Execute:
 
@@ -368,7 +405,7 @@ $post = $response->dto();
 
 ## Transactions
 
-Run multiple entities atomically on the same connection:
+Run multiple entities atomically on the same connection. The second argument accepts a connection name or a `Connection` instance:
 
 ```php
 use BitMx\DataEntities\DataEntity;
@@ -377,9 +414,13 @@ DataEntity::transaction(function () {
     (new CreateOrderDataEntity($payload))->execute();
     (new ReserveInventoryDataEntity($orderId))->execute();
 }, connection: 'sqlsrv');
+
+DataEntity::transaction(function () {
+    (new CreateOrderDataEntity($payload))->execute();
+}, connection: $dynamicConnection);
 ```
 
-Equivalent to `DB::connection('sqlsrv')->transaction(...)`. Different connections cannot share one transaction.
+Equivalent to `DB::connection('sqlsrv')->transaction(...)` when passing a name. Different connections cannot share one transaction.
 
 ## Debugging
 

--- a/src/Cache/CacheKey.php
+++ b/src/Cache/CacheKey.php
@@ -13,7 +13,7 @@ class CacheKey
         $dataEntity = $pendingQuery->getDataEntity();
         $className = $dataEntity::class;
         $storeProcedure = $dataEntity->resolveStoreProcedure();
-        $connection = $dataEntity->resolveDatabaseConnection();
+        $connection = $dataEntity->resolveDatabaseConnectionIdentity();
         $parameters = $pendingQuery->parameters()->all();
         $outputParameters = $pendingQuery->outputParameters()->all();
 

--- a/src/Commands/CheckDataEntities.php
+++ b/src/Commands/CheckDataEntities.php
@@ -37,18 +37,19 @@ class CheckDataEntities extends Command
             /** @var DataEntity $entity */
             $entity = $reflection->newInstanceWithoutConstructor();
             $procedure = $entity->resolveStoreProcedure();
-            $connection = $entity->resolveDatabaseConnection();
+            $connection = $entity->resolveEffectiveDatabaseConnection();
+            $connectionLabel = $entity->resolveDatabaseConnectionIdentity();
             $introspector = $resolver->resolve($connection);
 
             if (! $introspector->procedureExists($procedure)) {
-                $this->components->error(sprintf('%s → procedure [%s] not found on [%s]', $class, $procedure, $connection));
+                $this->components->error(sprintf('%s → procedure [%s] not found on [%s]', $class, $procedure, $connectionLabel));
                 $failures++;
 
                 continue;
             }
 
             if (($reflection->getConstructor()?->getNumberOfRequiredParameters() ?? 0) > 0) {
-                $this->components->info(sprintf('%s → procedure exists (%s on %s); skipped parameter drift (constructor required)', $class, $procedure, $connection));
+                $this->components->info(sprintf('%s → procedure exists (%s on %s); skipped parameter drift (constructor required)', $class, $procedure, $connectionLabel));
 
                 continue;
             }
@@ -76,13 +77,13 @@ class CheckDataEntities extends Command
             $extraOutputs = array_values(array_diff($entityOutputs, $dbOutputs));
 
             if ($missingInputs === [] && $extraInputs === [] && $missingOutputs === [] && $extraOutputs === []) {
-                $this->components->info(sprintf('%s → OK (%s on %s)', $class, $procedure, $connection));
+                $this->components->info(sprintf('%s → OK (%s on %s)', $class, $procedure, $connectionLabel));
 
                 continue;
             }
 
             $failures++;
-            $this->components->error(sprintf('%s → drift detected for [%s] on [%s]', $class, $procedure, $connection));
+            $this->components->error(sprintf('%s → drift detected for [%s] on [%s]', $class, $procedure, $connectionLabel));
 
             if ($missingInputs !== []) {
                 $this->line('  missing inputs: '.implode(', ', $missingInputs));

--- a/src/Commands/ListDataEntities.php
+++ b/src/Commands/ListDataEntities.php
@@ -36,7 +36,7 @@ class ListDataEntities extends Command
             $rows[] = [
                 $class,
                 $entity->resolveStoreProcedure(),
-                $entity->resolveDatabaseConnection(),
+                $entity->resolveDatabaseConnectionIdentity(),
             ];
         }
 

--- a/src/Executers/QueryExecutorResolver.php
+++ b/src/Executers/QueryExecutorResolver.php
@@ -7,6 +7,7 @@ namespace BitMx\DataEntities\Executers;
 use BitMx\DataEntities\Exceptions\UnsupportedQueryExecutorException;
 use BitMx\DataEntities\Executers\Contracts\QueryExecutorContract;
 use BitMx\DataEntities\PendingQuery;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
 
 class QueryExecutorResolver
@@ -16,7 +17,7 @@ class QueryExecutorResolver
         $dataEntity = $pendingQuery->getDataEntity();
 
         $executorClass = $dataEntity->resolveQueryExecutor()
-            ?? $this->resolveFromDriver($dataEntity->resolveDatabaseConnection());
+            ?? $this->resolveFromDriver($dataEntity->resolveEffectiveDatabaseConnection());
 
         return $this->make($executorClass);
     }
@@ -35,9 +36,9 @@ class QueryExecutorResolver
     /**
      * @return class-string<QueryExecutorContract>
      */
-    protected function resolveFromDriver(string $connectionName): string
+    protected function resolveFromDriver(string|Connection $connection): string
     {
-        $driver = $this->resolveDriverName($connectionName);
+        $driver = $this->resolveDriverName($connection);
 
         /** @var array<string, class-string<QueryExecutorContract>> $executers */
         $executers = config('data-entities.executers', []);
@@ -51,14 +52,18 @@ class QueryExecutorResolver
         return $executers[$driver];
     }
 
-    protected function resolveDriverName(string $connectionName): string
+    protected function resolveDriverName(string|Connection $connection): string
     {
-        $driver = config("database.connections.{$connectionName}.driver");
+        if ($connection instanceof Connection) {
+            return $connection->getDriverName();
+        }
+
+        $driver = config("database.connections.{$connection}.driver");
 
         if (is_string($driver) && $driver !== '') {
             return $driver;
         }
 
-        return DB::connection($connectionName)->getDriverName();
+        return DB::connection($connection)->getDriverName();
     }
 }

--- a/src/Introspection/MySqlProcedureIntrospector.php
+++ b/src/Introspection/MySqlProcedureIntrospector.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace BitMx\DataEntities\Introspection;
 
 use BitMx\DataEntities\Introspection\Contracts\ProcedureIntrospectorContract;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
 
 class MySqlProcedureIntrospector implements ProcedureIntrospectorContract
 {
     public function __construct(
-        protected readonly string $connection,
+        protected readonly string|Connection $connection,
     ) {}
 
     public function procedureExists(string $procedure): bool
     {
         $name = $this->unqualifiedName($procedure);
 
-        $result = DB::connection($this->connection)->selectOne(
+        $result = $this->client()->selectOne(
             'SELECT COUNT(*) AS aggregate
              FROM information_schema.routines
              WHERE routine_schema = DATABASE()
@@ -39,7 +40,7 @@ class MySqlProcedureIntrospector implements ProcedureIntrospectorContract
     {
         $name = $this->unqualifiedName($procedure);
 
-        $rows = DB::connection($this->connection)->select(
+        $rows = $this->client()->select(
             'SELECT PARAMETER_NAME, DATA_TYPE, DTD_IDENTIFIER, PARAMETER_MODE
              FROM information_schema.parameters
              WHERE SPECIFIC_SCHEMA = DATABASE()
@@ -67,6 +68,15 @@ class MySqlProcedureIntrospector implements ProcedureIntrospectorContract
         }
 
         return $parameters;
+    }
+
+    protected function client(): Connection
+    {
+        if ($this->connection instanceof Connection) {
+            return $this->connection;
+        }
+
+        return DB::connection($this->connection);
     }
 
     protected function unqualifiedName(string $procedure): string

--- a/src/Introspection/ProcedureIntrospectorResolver.php
+++ b/src/Introspection/ProcedureIntrospectorResolver.php
@@ -6,31 +6,36 @@ namespace BitMx\DataEntities\Introspection;
 
 use BitMx\DataEntities\Exceptions\UnsupportedQueryExecutorException;
 use BitMx\DataEntities\Introspection\Contracts\ProcedureIntrospectorContract;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
 
 class ProcedureIntrospectorResolver
 {
-    public function resolve(string $connectionName): ProcedureIntrospectorContract
+    public function resolve(string|Connection $connection): ProcedureIntrospectorContract
     {
-        $driver = $this->resolveDriverName($connectionName);
+        $driver = $this->resolveDriverName($connection);
 
         return match ($driver) {
-            'sqlsrv' => new SqlServerProcedureIntrospector($connectionName),
-            'mysql' => new MySqlProcedureIntrospector($connectionName),
+            'sqlsrv' => new SqlServerProcedureIntrospector($connection),
+            'mysql' => new MySqlProcedureIntrospector($connection),
             default => throw new UnsupportedQueryExecutorException(
                 sprintf('No procedure introspector registered for driver [%s].', $driver)
             ),
         };
     }
 
-    protected function resolveDriverName(string $connectionName): string
+    protected function resolveDriverName(string|Connection $connection): string
     {
-        $driver = config("database.connections.{$connectionName}.driver");
+        if ($connection instanceof Connection) {
+            return $connection->getDriverName();
+        }
+
+        $driver = config("database.connections.{$connection}.driver");
 
         if (is_string($driver) && $driver !== '') {
             return $driver;
         }
 
-        return DB::connection($connectionName)->getDriverName();
+        return DB::connection($connection)->getDriverName();
     }
 }

--- a/src/Introspection/SqlServerProcedureIntrospector.php
+++ b/src/Introspection/SqlServerProcedureIntrospector.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace BitMx\DataEntities\Introspection;
 
 use BitMx\DataEntities\Introspection\Contracts\ProcedureIntrospectorContract;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
 
 class SqlServerProcedureIntrospector implements ProcedureIntrospectorContract
 {
     public function __construct(
-        protected readonly string $connection,
+        protected readonly string|Connection $connection,
     ) {}
 
     public function procedureExists(string $procedure): bool
     {
         [$schema, $name] = $this->splitName($procedure);
 
-        $result = DB::connection($this->connection)->selectOne(
+        $result = $this->client()->selectOne(
             'SELECT COUNT(*) AS aggregate
              FROM sys.procedures p
              INNER JOIN sys.schemas s ON s.schema_id = p.schema_id
@@ -38,7 +39,7 @@ class SqlServerProcedureIntrospector implements ProcedureIntrospectorContract
     {
         [$schema, $name] = $this->splitName($procedure);
 
-        $rows = DB::connection($this->connection)->select(
+        $rows = $this->client()->select(
             'SELECT
                 REPLACE(par.name, \'@\', \'\') AS parameter_name,
                 TYPE_NAME(par.user_type_id) AS data_type,
@@ -69,6 +70,15 @@ class SqlServerProcedureIntrospector implements ProcedureIntrospectorContract
         }
 
         return $parameters;
+    }
+
+    protected function client(): Connection
+    {
+        if ($this->connection instanceof Connection) {
+            return $this->connection;
+        }
+
+        return DB::connection($this->connection);
     }
 
     /**

--- a/src/Processors/Processor.php
+++ b/src/Processors/Processor.php
@@ -19,7 +19,6 @@ use BitMx\DataEntities\Traits\Executer\HasQuery;
 use Illuminate\Database\Connection;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\LazyCollection;
 use PDO;
@@ -168,7 +167,7 @@ class Processor implements ProcessorContract
 
     protected function getClient(): Connection
     {
-        $connection = DB::connection($this->pendingQuery->getDataEntity()->resolveDatabaseConnection());
+        $connection = $this->pendingQuery->getDataEntity()->resolveConnection();
         $timeout = $this->pendingQuery->getDataEntity()->queryTimeout();
 
         if ($timeout !== null) {

--- a/src/Traits/DataEntity/HasConnection.php
+++ b/src/Traits/DataEntity/HasConnection.php
@@ -4,12 +4,80 @@ declare(strict_types=1);
 
 namespace BitMx\DataEntities\Traits\DataEntity;
 
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\DB;
+
 trait HasConnection
 {
-    public function resolveDatabaseConnection(): string
+    protected string|Connection|null $connectionOverride = null;
+
+    /**
+     * Resolve the configured database connection name or instance.
+     *
+     * Override to return a Laravel connection name or a live Connection.
+     * Runtime overrides via onConnection() take precedence.
+     */
+    public function resolveDatabaseConnection(): string|Connection
     {
         $connection = config('data-entities.database', 'sqlsrv');
 
         return is_string($connection) && $connection !== '' ? $connection : 'sqlsrv';
+    }
+
+    /**
+     * Override the connection for this entity instance (runtime).
+     *
+     * Precedence: onConnection() > resolveDatabaseConnection() > config.
+     */
+    public function onConnection(string|Connection $connection): static
+    {
+        $this->connectionOverride = $connection;
+
+        return $this;
+    }
+
+    /**
+     * Effective connection before normalizing to a live Connection instance.
+     */
+    public function resolveEffectiveDatabaseConnection(): string|Connection
+    {
+        return $this->connectionOverride ?? $this->resolveDatabaseConnection();
+    }
+
+    /**
+     * Resolve the effective connection to a live Connection instance.
+     */
+    public function resolveConnection(): Connection
+    {
+        $resolved = $this->resolveEffectiveDatabaseConnection();
+
+        if ($resolved instanceof Connection) {
+            return $resolved;
+        }
+
+        return DB::connection($resolved);
+    }
+
+    /**
+     * Stable string identity for cache keys, list/check commands, and display.
+     */
+    public function resolveDatabaseConnectionIdentity(): string
+    {
+        return $this->connectionIdentity($this->resolveEffectiveDatabaseConnection());
+    }
+
+    protected function connectionIdentity(string|Connection $connection): string
+    {
+        if (is_string($connection)) {
+            return $connection;
+        }
+
+        $name = $connection->getName();
+
+        if (is_string($name) && $name !== '') {
+            return $name;
+        }
+
+        return $connection->getDriverName().':'.$connection->getDatabaseName();
     }
 }

--- a/src/Traits/DataEntity/HasTransactions.php
+++ b/src/Traits/DataEntity/HasTransactions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BitMx\DataEntities\Traits\DataEntity;
 
 use Closure;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
 
 trait HasTransactions
@@ -20,8 +21,12 @@ trait HasTransactions
      * @param  Closure(): TReturn  $callback
      * @return TReturn
      */
-    public static function transaction(Closure $callback, ?string $connection = null): mixed
+    public static function transaction(Closure $callback, string|Connection|null $connection = null): mixed
     {
+        if ($connection instanceof Connection) {
+            return $connection->transaction($callback);
+        }
+
         if ($connection !== null) {
             $connectionName = $connection;
         } else {

--- a/tests/Unit/DataEntity/HasConnectionTest.php
+++ b/tests/Unit/DataEntity/HasConnectionTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+use BitMx\DataEntities\Cache\CacheKey;
+use BitMx\DataEntities\DataEntity;
+use BitMx\DataEntities\Enums\Method;
+use BitMx\DataEntities\Executers\MySqlQueryExecutor;
+use BitMx\DataEntities\Executers\QueryExecutorResolver;
+use BitMx\DataEntities\Executers\SqlServerQueryExecutor;
+use BitMx\DataEntities\PendingQuery;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\DB;
+
+it('resolves a string connection name from config by default', function () {
+    config()->set('data-entities.database', 'sqlsrv');
+
+    $dataEntity = new class extends DataEntity
+    {
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+    };
+
+    expect($dataEntity->resolveDatabaseConnection())->toBe('sqlsrv')
+        ->and($dataEntity->resolveDatabaseConnectionIdentity())->toBe('sqlsrv');
+});
+
+it('allows resolveDatabaseConnection to return a Connection instance', function () {
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getName')->andReturn('tenant_dynamic');
+    $connection->shouldReceive('getDriverName')->andReturn('mysql');
+    $connection->shouldReceive('getDatabaseName')->andReturn('tenant_db');
+
+    $dataEntity = new class($connection) extends DataEntity
+    {
+        public function __construct(protected Connection $dynamicConnection) {}
+
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+
+        public function resolveDatabaseConnection(): string|Connection
+        {
+            return $this->dynamicConnection;
+        }
+    };
+
+    expect($dataEntity->resolveDatabaseConnection())->toBe($connection)
+        ->and($dataEntity->resolveConnection())->toBe($connection)
+        ->and($dataEntity->resolveDatabaseConnectionIdentity())->toBe('tenant_dynamic');
+});
+
+it('prefers onConnection override over resolveDatabaseConnection', function () {
+    config()->set('data-entities.database', 'sqlsrv');
+
+    $override = Mockery::mock(Connection::class);
+    $override->shouldReceive('getName')->andReturn('runtime_conn');
+    $override->shouldReceive('getDriverName')->andReturn('mysql');
+    $override->shouldReceive('getDatabaseName')->andReturn('runtime_db');
+
+    $dataEntity = new class extends DataEntity
+    {
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+
+        public function resolveDatabaseConnection(): string|Connection
+        {
+            return 'sqlsrv';
+        }
+    };
+
+    $dataEntity->onConnection($override);
+
+    expect($dataEntity->resolveEffectiveDatabaseConnection())->toBe($override)
+        ->and($dataEntity->resolveConnection())->toBe($override)
+        ->and($dataEntity->resolveDatabaseConnectionIdentity())->toBe('runtime_conn');
+});
+
+it('allows onConnection with a string name', function () {
+    config()->set('data-entities.database', 'sqlsrv');
+
+    $resolved = Mockery::mock(Connection::class);
+
+    DB::shouldReceive('connection')
+        ->once()
+        ->with('tenant_mysql')
+        ->andReturn($resolved);
+
+    $dataEntity = new class extends DataEntity
+    {
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+    };
+
+    $dataEntity->onConnection('tenant_mysql');
+
+    expect($dataEntity->resolveEffectiveDatabaseConnection())->toBe('tenant_mysql')
+        ->and($dataEntity->resolveConnection())->toBe($resolved)
+        ->and($dataEntity->resolveDatabaseConnectionIdentity())->toBe('tenant_mysql');
+});
+
+it('falls back to driver:database when Connection has no name', function () {
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getName')->andReturn(null);
+    $connection->shouldReceive('getDriverName')->andReturn('sqlsrv');
+    $connection->shouldReceive('getDatabaseName')->andReturn('legacy');
+
+    $dataEntity = new class($connection) extends DataEntity
+    {
+        public function __construct(protected Connection $dynamicConnection) {}
+
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+
+        public function resolveDatabaseConnection(): string|Connection
+        {
+            return $this->dynamicConnection;
+        }
+    };
+
+    expect($dataEntity->resolveDatabaseConnectionIdentity())->toBe('sqlsrv:legacy');
+});
+
+it('changes the cache key when onConnection overrides the connection', function () {
+    config()->set('data-entities.database', 'sqlsrv');
+
+    $dataEntity = new class extends DataEntity
+    {
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+    };
+
+    $withoutOverride = CacheKey::create(new PendingQuery($dataEntity));
+
+    $dataEntity->onConnection('mysql');
+    $withOverride = CacheKey::create(new PendingQuery($dataEntity));
+
+    expect($withoutOverride)->not->toBe($withOverride)
+        ->and($withOverride)->toContain('"connection":"mysql"');
+});
+
+it('resolves the query executor from a Connection driver', function () {
+    config()->set('data-entities.executers.mysql', MySqlQueryExecutor::class);
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getDriverName')->andReturn('mysql');
+
+    $dataEntity = new class($connection) extends DataEntity
+    {
+        protected ?Method $method = Method::SELECT;
+
+        public function __construct(protected Connection $dynamicConnection) {}
+
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+
+        public function resolveDatabaseConnection(): string|Connection
+        {
+            return $this->dynamicConnection;
+        }
+    };
+
+    $executor = (new QueryExecutorResolver)->resolve(new PendingQuery($dataEntity));
+
+    expect($executor)->toBeInstanceOf(MySqlQueryExecutor::class);
+});
+
+it('resolves the query executor from onConnection override', function () {
+    config()->set('data-entities.database', 'sqlsrv');
+    config()->set('database.connections.sqlsrv.driver', 'sqlsrv');
+    config()->set('data-entities.executers.sqlsrv', SqlServerQueryExecutor::class);
+    config()->set('data-entities.executers.mysql', MySqlQueryExecutor::class);
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getDriverName')->andReturn('mysql');
+
+    $dataEntity = new class extends DataEntity
+    {
+        protected ?Method $method = Method::SELECT;
+
+        public function resolveStoreProcedure(): string
+        {
+            return 'sp_test';
+        }
+
+        public function resolveDatabaseConnection(): string|Connection
+        {
+            return 'sqlsrv';
+        }
+    };
+
+    $dataEntity->onConnection($connection);
+
+    $executor = (new QueryExecutorResolver)->resolve(new PendingQuery($dataEntity));
+
+    expect($executor)->toBeInstanceOf(MySqlQueryExecutor::class);
+});

--- a/tests/Unit/DataEntity/HasTransactionsTest.php
+++ b/tests/Unit/DataEntity/HasTransactionsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use BitMx\DataEntities\DataEntity;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\DB;
 
 it('runs the callback inside a database transaction on the given connection', function () {
@@ -43,7 +44,7 @@ it('defaults to the configured data-entities database connection', function () {
 });
 
 it('accepts a Connection instance for the transaction', function () {
-    $connection = Mockery::mock(\Illuminate\Database\Connection::class);
+    $connection = Mockery::mock(Connection::class);
     $connection->shouldReceive('transaction')
         ->once()
         ->with(Mockery::type('callable'))

--- a/tests/Unit/DataEntity/HasTransactionsTest.php
+++ b/tests/Unit/DataEntity/HasTransactionsTest.php
@@ -41,3 +41,18 @@ it('defaults to the configured data-entities database connection', function () {
 
     expect(DataEntity::transaction(fn () => 42))->toBe(42);
 });
+
+it('accepts a Connection instance for the transaction', function () {
+    $connection = Mockery::mock(\Illuminate\Database\Connection::class);
+    $connection->shouldReceive('transaction')
+        ->once()
+        ->with(Mockery::type('callable'))
+        ->andReturnUsing(fn (callable $callback) => $callback());
+
+    $result = DataEntity::transaction(
+        fn () => 'from-connection',
+        $connection,
+    );
+
+    expect($result)->toBe('from-connection');
+});


### PR DESCRIPTION
Support string|Connection resolution, runtime overrides, and document DB::build for ad-hoc credentials without named config entries.
